### PR TITLE
Update comment to reflect correct dimensionality in `nib_to_sitk` function

### DIFF
--- a/src/torchio/data/io.py
+++ b/src/torchio/data/io.py
@@ -306,7 +306,7 @@ def nib_to_sitk(
     # Possibilities
     # (1, w, h, 1)
     # (c, w, h, 1)
-    # (1, w, h, 1)
+    # (1, w, h, d)
     # (c, w, h, d)
     array = np.asarray(data)
     affine = np.asarray(affine).astype(np.float64)


### PR DESCRIPTION
Fixes #1269.

**Description**

In [torchio/src/torchio/data/io.py](https://github.com/TorchIO-project/torchio/blob/main/src/torchio/data/io.py), the `nib_to_sitk` function [here](https://github.com/TorchIO-project/torchio/blob/main/src/torchio/data/io.py#L296C5-L296C16), has the following comments indicating the possible shapes of input parameter `data`:
```
    # Possibilities
    # (1, w, h, 1)
    # (c, w, h, 1)
    # (1, w, h, 1)
    # (c, w, h, d)
```
The third possibility should be (1, w, h, `d`) instead. Otherwise, it would be a repeat of the first.
After correction:
```
    # Possibilities
    # (1, w, h, 1)
    # (c, w, h, 1)
    # (1, w, h, d)
    # (c, w, h, d)
```

**Checklist**

- [x] I have read the [`CONTRIBUTING`](https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup (especially important are `pre-commit`and `pytest`)
- [x] Non-breaking change (would not break existing functionality)
- [ ] Breaking change (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] Integration tests passed locally by running `pytest`
- [ ] In-line docstrings updated
- [ ] Documentation updated, tested running `make html` inside the `docs/` folder
- [x] This pull request is ready to be reviewed
