### PR TITLE
Add option to skip crop or pad in CropOrPad

### DIFF
--- a/src/torchio/transforms/preprocessing/spatial/crop_or_pad.py
+++ b/src/torchio/transforms/preprocessing/spatial/crop_or_pad.py
@@ -34,12 +34,10 @@ class CropOrPad(SpatialTransform):
             :attr:`mask_name`.
         labels: If a label map is used to generate the mask, sequence of labels
             to consider.
-        apply_crop: If ``False``, the volume will not be cropped even if the
-            target shape is smaller than the input shape. At least one of
-            ``apply_crop`` or ``apply_pad`` must be ``True``.
-        apply_pad: If ``False``, the volume will not be padded even if the
-            target shape is larger than the input shape. At least one of
-            ``apply_crop`` or ``apply_pad`` must be ``True``.
+        only_crop: If ``True``, padding will not be applied, only cropping will
+            be done. ``only_crop`` and ``only_pad`` cannot both be ``True``.
+        only_pad: If ``True``, cropping will not be applied, only padding will
+            be done. ``only_crop`` and ``only_pad`` cannot both be ``True``.
         **kwargs: See :class:`~torchio.transforms.Transform` for additional
             keyword arguments.
 
@@ -82,8 +80,8 @@ class CropOrPad(SpatialTransform):
         padding_mode: Union[str, float] = 0,
         mask_name: Optional[str] = None,
         labels: Optional[Sequence[int]] = None,
-        apply_crop: bool = True,
-        apply_pad: bool = True,
+        only_crop: bool = False,
+        only_pad: bool = False,
         **kwargs,
     ):
         if target_shape is None and mask_name is None:
@@ -119,11 +117,11 @@ class CropOrPad(SpatialTransform):
         self.mask_name = mask_name
         self.labels = labels
 
-        if not (apply_crop or apply_pad):
-            message = 'At least one of apply_crop or apply_pad must be True'
+        if only_pad and only_crop:
+            message = 'only_crop and only_pad cannot both be True'
             raise ValueError(message)
-        self.apply_crop = apply_crop
-        self.apply_pad = apply_pad
+        self.only_crop = only_crop
+        self.only_pad = only_pad
 
     @staticmethod
     def _bbox_mask(mask_volume: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
@@ -291,10 +289,10 @@ class CropOrPad(SpatialTransform):
         subject.check_consistent_space()
         padding_params, cropping_params = self.compute_crop_or_pad(subject)
         padding_kwargs = {'padding_mode': self.padding_mode}
-        if self.apply_pad and padding_params is not None:
+        if padding_params is not None and not self.only_crop:
             pad = Pad(padding_params, **self.get_base_args(), **padding_kwargs)
             subject = pad(subject)  # type: ignore[assignment]
-        if self.apply_crop and cropping_params is not None:
+        if cropping_params is not None and not self.only_pad:
             crop = Crop(cropping_params, **self.get_base_args())
             subject = crop(subject)  # type: ignore[assignment]
         return subject

--- a/tests/transforms/preprocessing/test_crop_pad.py
+++ b/tests/transforms/preprocessing/test_crop_pad.py
@@ -212,3 +212,31 @@ class TestCropOrPad(TorchioTestCase):
             shape_a = crop(subject_a).image.shape
             shape_b = crop(subject_b).image.shape
             assert shape_a != shape_b
+
+    def test_apply_crop_pad_false(self):
+        with pytest.raises(ValueError):
+            tio.CropOrPad((1, 2, 3), apply_crop=False, apply_pad=False)
+
+    def test_apply_crop_false(self):
+        target_shape = 9, 21, 30
+        orig_shape = self.sample_subject['t1'].spatial_shape
+        expected_shape = tuple(
+            t if t > o else o for o, t in zip(orig_shape, target_shape)
+        )
+        transform = tio.CropOrPad(target_shape, apply_crop=False)
+        transformed = transform(self.sample_subject)
+        for key in transformed:
+            result_shape = transformed[key].spatial_shape
+            assert result_shape == expected_shape
+
+    def test_apply_pad_false(self):
+        target_shape = 9, 21, 30
+        orig_shape = self.sample_subject['t1'].spatial_shape
+        expected_shape = tuple(
+            t if t < o else o for o, t in zip(orig_shape, target_shape)
+        )
+        transform = tio.CropOrPad(target_shape, apply_pad=False)
+        transformed = transform(self.sample_subject)
+        for key in transformed:
+            result_shape = transformed[key].spatial_shape
+            assert result_shape == expected_shape

--- a/tests/transforms/preprocessing/test_crop_pad.py
+++ b/tests/transforms/preprocessing/test_crop_pad.py
@@ -213,29 +213,29 @@ class TestCropOrPad(TorchioTestCase):
             shape_b = crop(subject_b).image.shape
             assert shape_a != shape_b
 
-    def test_apply_crop_pad_false(self):
+    def test_only_crop_pad_true(self):
         with pytest.raises(ValueError):
-            tio.CropOrPad((1, 2, 3), apply_crop=False, apply_pad=False)
+            tio.CropOrPad((1, 2, 3), only_crop=True, only_pad=True)
 
-    def test_apply_crop_false(self):
+    def test_only_pad_true(self):
         target_shape = 9, 21, 30
         orig_shape = self.sample_subject['t1'].spatial_shape
         expected_shape = tuple(
             t if t > o else o for o, t in zip(orig_shape, target_shape)
         )
-        transform = tio.CropOrPad(target_shape, apply_crop=False)
+        transform = tio.CropOrPad(target_shape, only_pad=True)
         transformed = transform(self.sample_subject)
         for key in transformed:
             result_shape = transformed[key].spatial_shape
             assert result_shape == expected_shape
 
-    def test_apply_pad_false(self):
+    def test_only_crop_true(self):
         target_shape = 9, 21, 30
         orig_shape = self.sample_subject['t1'].spatial_shape
         expected_shape = tuple(
             t if t < o else o for o, t in zip(orig_shape, target_shape)
         )
-        transform = tio.CropOrPad(target_shape, apply_pad=False)
+        transform = tio.CropOrPad(target_shape, only_crop=True)
         transformed = transform(self.sample_subject)
         for key in transformed:
             result_shape = transformed[key].spatial_shape


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR.
For example: Fixes #37.
If there isn't one, delete the line below. -->

Fixes #1234 .

**Description**

Added `apply_crop` and `apply_pad` flags to `CropOrPad` so that if we only want to crop or pad then we can skip the other part. This allows us to pad to a target shape, for example, ensuring a minimum size of the volume without cropping larger volumes, or vice versa.

<!-- Write a few sentences describing the changes proposed in this pull request. -->

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup ready
- Changes are
  - [x] Non-breaking (would not break existing functionality)
  - [ ] Breaking (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] In-line docstrings updated
- [ ] Documentation updated
- [x] This pull request is ready to be reviewed
