### PR TITLE
Make resampling symmetric

### DIFF
--- a/src/torchio/transforms/preprocessing/spatial/resample.py
+++ b/src/torchio/transforms/preprocessing/spatial/resample.py
@@ -301,7 +301,7 @@ class Resample(SpatialTransform):
         old_origin_lps = np.array(floating_sitk.GetOrigin(), dtype=float)
         center_lps = (old_last_index_lps + old_origin_lps) / 2
         # We use floor to avoid extrapolation by keeping the extent of the
-        # new image the sale or smaller than the original.
+        # new image the same or smaller than the original.
         new_size = np.floor(old_size * old_spacing / new_spacing)
         # We keep singleton dimensions to avoid e.g. making 2D images 3D
         new_size[old_size == 1] = 1

--- a/src/torchio/transforms/preprocessing/spatial/resample.py
+++ b/src/torchio/transforms/preprocessing/spatial/resample.py
@@ -290,18 +290,22 @@ class Resample(SpatialTransform):
         floating_sitk: sitk.Image,
         spacing: TypeTripletFloat,
     ) -> sitk.Image:
-        old_spacing = np.array(floating_sitk.GetSpacing())
-        new_spacing = np.array(spacing)
+        old_spacing = np.array(floating_sitk.GetSpacing(), dtype=float)
+        new_spacing = np.array(spacing, dtype=float)
         old_size = np.array(floating_sitk.GetSize())
-        new_size = old_size * old_spacing / new_spacing
-        new_size = np.ceil(new_size).astype(np.uint16)
-        new_size[old_size == 1] = 1  # keep singleton dimensions
-        new_origin_index = 0.5 * (new_spacing / old_spacing - 1)
-        new_origin_lps = floating_sitk.TransformContinuousIndexToPhysicalPoint(
-            new_origin_index,
+        old_last_index = old_size - 1
+        old_last_index_lps = np.array(
+            floating_sitk.TransformIndexToPhysicalPoint(old_last_index.tolist()),
+            dtype=float,
         )
+        old_origin_lps = np.array(floating_sitk.GetOrigin(), dtype=float)
+        center_lps = (old_last_index_lps + old_origin_lps) / 2
+        new_size = np.floor(old_size * old_spacing / new_spacing)  # avoid extrapolation
+        direction = np.asarray(floating_sitk.GetDirection(), dtype=float).reshape(3, 3)
+        half_extent = (new_size - 1) / 2 * new_spacing
+        new_origin_lps = (center_lps - direction @ half_extent).tolist()
         reference = sitk.Image(
-            new_size.tolist(),
+            new_size.astype(int).tolist(),
             floating_sitk.GetPixelID(),
             floating_sitk.GetNumberOfComponentsPerPixel(),
         )

--- a/src/torchio/transforms/preprocessing/spatial/resample.py
+++ b/src/torchio/transforms/preprocessing/spatial/resample.py
@@ -300,7 +300,11 @@ class Resample(SpatialTransform):
         )
         old_origin_lps = np.array(floating_sitk.GetOrigin(), dtype=float)
         center_lps = (old_last_index_lps + old_origin_lps) / 2
-        new_size = np.floor(old_size * old_spacing / new_spacing)  # avoid extrapolation
+        # We use floor to avoid extrapolation by keeping the extent of the
+        # new image the sale or smaller than the original.
+        new_size = np.floor(old_size * old_spacing / new_spacing)
+        # We keep singleton dimensions to avoid e.g. making 2D images 3D
+        new_size[old_size == 1] = 1
         direction = np.asarray(floating_sitk.GetDirection(), dtype=float).reshape(3, 3)
         half_extent = (new_size - 1) / 2 * new_spacing
         new_origin_lps = (center_lps - direction @ half_extent).tolist()

--- a/src/torchio/transforms/preprocessing/spatial/resize.py
+++ b/src/torchio/transforms/preprocessing/spatial/resize.py
@@ -66,7 +66,6 @@ class Resize(SpatialTransform):
         resampled = resample(subject)
         assert isinstance(resampled, Subject)
         # Sometimes, the output shape is one voxel too large
-        # Probably because Resample uses np.ceil to compute the shape
         if not resampled.spatial_shape == tuple(shape_out):
             message = (
                 f'Output shape {resampled.spatial_shape}'

--- a/tests/transforms/preprocessing/test_resample.py
+++ b/tests/transforms/preprocessing/test_resample.py
@@ -78,6 +78,7 @@ class TestResample(TorchioTestCase):
             transform(self.sample_subject)
 
     def test_2d(self):
+        """Check that image is still 2D after resampling."""
         image = tio.ScalarImage(tensor=torch.rand(1, 2, 3, 1))
         transform = tio.Resample(0.5)
         shape = transform(image).shape

--- a/tests/transforms/preprocessing/test_resample.py
+++ b/tests/transforms/preprocessing/test_resample.py
@@ -100,3 +100,14 @@ class TestResample(TorchioTestCase):
         transform = tio.Resample(target)
         with pytest.raises(RuntimeError):
             transform(self.sample_subject)
+
+    def test_resample_flip(self):
+        image = torch.rand(1, 10, 10, 10)
+        resample = tio.Resample(1.35)
+        flip = tio.Flip(0)
+        flipped_and_resampled = resample(flip(image))
+        resampled_and_flipped = flip(resample(image))
+        self.assert_tensor_almost_equal(
+            flipped_and_resampled.data,
+            resampled_and_flipped.data,
+        )

--- a/tests/transforms/preprocessing/test_resample.py
+++ b/tests/transforms/preprocessing/test_resample.py
@@ -102,7 +102,7 @@ class TestResample(TorchioTestCase):
         with pytest.raises(RuntimeError):
             transform(self.sample_subject)
 
-    def test_resample_flip(self):
+    def test_resample_flip_consistent(self):
         image = torch.rand(1, 10, 10, 10)
         resample = tio.Resample(1.35)
         flip = tio.Flip(0)

--- a/tests/transforms/preprocessing/test_resize.py
+++ b/tests/transforms/preprocessing/test_resize.py
@@ -1,7 +1,3 @@
-import numpy as np
-import pytest
-import torch
-
 import torchio as tio
 
 from ...utils import TorchioTestCase
@@ -23,13 +19,3 @@ class TestResize(TorchioTestCase):
         transformed = transform(self.sample_subject)
         for image in transformed.get_images(intensity_only=False):
             assert image.spatial_shape == target_shape
-
-    def test_fix_shape(self):
-        # We use values that are known to need cropping
-        tensor = torch.rand(1, 8, 180, 320)
-        affine = np.diag((5, 1, 1, 1))
-        im = tio.ScalarImage(tensor=tensor, affine=affine)
-        target = 12
-        with pytest.warns(RuntimeWarning):
-            result = tio.Resize(target)(im)
-        assert result.spatial_shape == 3 * (target,)


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR.
For example: Fixes #37.
If there isn't one, delete the line below. -->

**Description**

<!-- Write a few sentences describing the changes proposed in this pull request. -->

INTERACTIVE DEMO: https://editor.p5js.org/fepegar/full/bsD299_fU

The current implementation aligns the input and output images at the boundaries closest to the origin index (here, bottom right, downsampling from 1 mm to 2.3 mm, green is input and magenta is output):

![image](https://github.com/user-attachments/assets/205b9538-7032-48e2-bac7-8a62fb322627)

This causes that e.g. `flip(resample(x)) != resample(flip(x))` (the new unit test fails on `main` and not here).

In this PR, I implemented something closer to grid 2 in https://ppwwyyxx.com/blog/2021/Where-are-Pixels/, where input and output are aligned at their geometrical center. Resampling the image above looks like this:

![image](https://github.com/user-attachments/assets/2ed728b2-528f-49b0-a9a3-89cfeabe201f)

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup ready
- Changes are
  - [x] Non-breaking (would not break existing functionality)
  - [ ] Breaking (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [ ] In-line docstrings updated
- [ ] Documentation updated
- [x] This pull request is ready to be reviewed
