### PR TITLE
Add option to not verify image path

### DIFF
--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -320,7 +320,7 @@ class TestImage(TorchioTestCase):
         image = tio.ScalarImage(path, verify_path=True)
         assert image.path == path
 
-        fake_path = 'fake_path.nii'
+        fake_path = Path('fake_path.nii')
 
         image = tio.ScalarImage(fake_path, verify_path=False)
         assert image.path == fake_path

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -322,8 +322,8 @@ class TestImage(TorchioTestCase):
 
         fake_path = 'fake_path.nii'
 
-        image = tio.ScalarImage(path, verify_path=False)
-        assert image.path == path
+        image = tio.ScalarImage(fake_path, verify_path=False)
+        assert image.path == fake_path
 
         with pytest.raises(FileNotFoundError):
             tio.ScalarImage(fake_path, verify_path=True)

--- a/tests/data/test_image.py
+++ b/tests/data/test_image.py
@@ -4,6 +4,7 @@
 import copy
 import sys
 import tempfile
+from pathlib import Path
 
 import nibabel as nib
 import numpy as np
@@ -309,3 +310,20 @@ class TestImage(TorchioTestCase):
 
         with pytest.raises(ValueError):
             image[3::-1]
+
+    def test_verify_path(self):
+        path = Path(self.get_image_path('im_verify'))
+
+        image = tio.ScalarImage(path, verify_path=False)
+        assert image.path == path
+
+        image = tio.ScalarImage(path, verify_path=True)
+        assert image.path == path
+
+        fake_path = 'fake_path.nii'
+
+        image = tio.ScalarImage(path, verify_path=False)
+        assert image.path == path
+
+        with pytest.raises(FileNotFoundError):
+            tio.ScalarImage(fake_path, verify_path=True)


### PR DESCRIPTION
<!-- Replace {issue_number} with the issue that will be closed after merging this PR.
For example: Fixes #37.
If there isn't one, delete the line below. -->

**Description (by Copilot)**

This pull request introduces a new `verify_path` parameter to the `Image` class in `torchio`, allowing users to control whether file path validation is performed. This enhancement improves flexibility when working with large datasets or mounted drives where path verification can be expensive. Additionally, new tests have been added to ensure the functionality of the `verify_path` parameter.

### Enhancements to `Image` class:

* Added the `verify_path` parameter to the `Image` class constructor, enabling optional file path validation. [[1]](diffhunk://#diff-e2bccb9f95e2760e5d3fb83d1f69a6baf170161568e7ec7b2bf7def3023b139aL99-R103) [[2]](diffhunk://#diff-e2bccb9f95e2760e5d3fb83d1f69a6baf170161568e7ec7b2bf7def3023b139aR143)
* Updated `_parse_path` and `_parse_single_path` methods to incorporate the `verify_path` parameter, skipping validation when set to `False`. [[1]](diffhunk://#diff-e2bccb9f95e2760e5d3fb83d1f69a6baf170161568e7ec7b2bf7def3023b139aL178-R183) [[2]](diffhunk://#diff-e2bccb9f95e2760e5d3fb83d1f69a6baf170161568e7ec7b2bf7def3023b139aR464-R465) [[3]](diffhunk://#diff-e2bccb9f95e2760e5d3fb83d1f69a6baf170161568e7ec7b2bf7def3023b139aR478-R479) [[4]](diffhunk://#diff-e2bccb9f95e2760e5d3fb83d1f69a6baf170161568e7ec7b2bf7def3023b139aR488-R499)

### Testing updates:

* Added `test_verify_path` to validate the behavior of the `verify_path` parameter, ensuring correct functionality for both valid and invalid paths.

<!-- Write a few sentences describing the changes proposed in this pull request. -->

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup ready
- Changes are
  - [x] Non-breaking (would not break existing functionality)
  - [ ] Breaking (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] In-line docstrings updated
- [ ] Documentation updated
- [x] This pull request is ready to be reviewed
