### PR TITLE
Revert warning when SubjectsLoader is not used

### DIFF
--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -33,7 +33,6 @@ from ..types import TypeTripletFloat
 from ..types import TypeTripletInt
 from ..utils import get_stem
 from ..utils import guess_external_viewer
-from ..utils import in_torch_loader
 from ..utils import is_iterable
 from ..utils import to_tuple
 from .io import check_uint_to_int
@@ -179,7 +178,6 @@ class Image(dict):
             warnings.warn(message, FutureWarning, stacklevel=2)
 
         super().__init__(**kwargs)
-        self._check_data_loader()
         self.path = self._parse_path(path, verify=verify_path)
 
         self[PATH] = '' if self.path is None else str(self.path)
@@ -237,20 +235,6 @@ class Image(dict):
             **kwargs,
         )
         return new_image
-
-    @staticmethod
-    def _check_data_loader() -> None:
-        if torch.__version__ >= '2.3' and in_torch_loader():
-            message = (
-                'Using TorchIO images without a torchio.SubjectsLoader in PyTorch >='
-                ' 2.3 might have unexpected consequences, e.g., the collated batches'
-                ' will be instances of torchio.Subject with 5D images. Replace'
-                ' your PyTorch DataLoader with a torchio.SubjectsLoader so that'
-                ' the collated batch becomes a dictionary, as expected. See'
-                ' https://github.com/TorchIO-project/torchio/issues/1179 for more'
-                ' context about this issue.'
-            )
-            warnings.warn(message, stacklevel=1)
 
     @property
     def data(self) -> torch.Tensor:

--- a/src/torchio/utils.py
+++ b/src/torchio/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import gzip
-import inspect
 import os
 import shutil
 import sys
@@ -15,7 +14,6 @@ from typing import Any
 import numpy as np
 import SimpleITK as sitk
 import torch
-import torch.utils.data.dataloader
 from nibabel.nifti1 import Nifti1Image
 from torch.utils.data import DataLoader
 from torch.utils.data._utils.collate import default_collate
@@ -412,24 +410,3 @@ def is_iterable(object: Any) -> bool:
         return True
     except TypeError:
         return False
-
-
-def in_class(classes) -> bool:
-    classes = to_tuple(classes)
-    stack = inspect.stack()
-    for frame_info in stack:
-        instance = frame_info.frame.f_locals.get('self')
-        if instance is None:
-            continue
-        if instance.__class__ in classes:
-            return True
-    else:
-        return False
-
-
-def in_torch_loader() -> bool:
-    classes = (
-        torch.utils.data.dataloader._SingleProcessDataLoaderIter,
-        torch.utils.data.dataloader._MultiProcessingDataLoaderIter,
-    )
-    return in_class(classes)


### PR DESCRIPTION
This reverts commit 5df163883448dd29f6c3015873cb7020ae7e9cca (#1215). It's too slow when e.g. instantiating a large dataset.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup ready
- Changes are
  - [x] Non-breaking (would not break existing functionality)
  - [ ] Breaking (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] In-line docstrings updated
- [ ] Documentation updated
- [x] This pull request is ready to be reviewed
