### PR TITLE
Stop loading image by default with tiohd

### DIFF
--- a/src/torchio/cli/print_info.py
+++ b/src/torchio/cli/print_info.py
@@ -33,7 +33,14 @@ def main(
         '-l/-s',
         help='Use torchio.LabelMap to instantiate the image.',
     ),
-):
+    load: bool = typer.Option(  # noqa: B008
+        False,
+        help=(
+            'Load the image from disk so that information about data type and memory '
+            'can be displayed. Slower, especially for large images.'
+        ),
+    ),
+) -> None:
     """Print information about an image and, optionally, show it.
 
     Example:
@@ -44,7 +51,8 @@ def main(
 
     class_ = tio.LabelMap if label else tio.ScalarImage
     image = class_(input_path)
-    image.load()
+    if load:
+        image.load()
     print(image)  # noqa: T201
     if plot:
         image.plot()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,7 +36,7 @@ class TestCLI(TorchioTestCase):
 
     def test_cli_hd(self):
         image = str(self.get_image_path('cli'))
-        args = [image]
+        args = [image, '--load']
         result = runner.invoke(print_info.app, args)
         assert result.exit_code == 0
         assert (


### PR DESCRIPTION
This greatly increases speed for large images, and most times we're mostly interested in spatial metadata anyway, which can be loaded very quickly.