### PR TITLE
Throw error on wrong files shape

### DIFF
--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -594,7 +594,7 @@ class Image(dict):
                     f'Files shape do not match, found {tensor.shape}'
                     f'and {new_tensor.shape}'
                 )
-                RuntimeError(message)
+                raise RuntimeError(message)
             tensors.append(new_tensor)
         tensor = torch.cat(tensors)
         self.set_data(tensor)


### PR DESCRIPTION
**Description**
This small PR throws an error on wrong files shape.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [x] I have read the [`CONTRIBUTING`](https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.rst) docs and have a developer setup ready
- Changes are
  - [x] Non-breaking (would not break existing functionality)
  - [ ] Breaking (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] In-line docstrings updated
- [ ] Documentation updated
- [x] This pull request is ready to be reviewed
