### PR TITLE
Replace distinctipy with colorcet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 
 [project.optional-dependencies]
 csv = ["pandas>=1"]
-plot = ["distinctipy>=1.3.4", "matplotlib>=3.4"]
+plot = ["colorcet", "matplotlib>=3.4"]
 video = ["ffmpeg-python>=0.2.0"]
 sklearn = [
     "scikit-learn>=1.6.1",

--- a/src/torchio/external/imports.py
+++ b/src/torchio/external/imports.py
@@ -26,8 +26,8 @@ def get_pandas() -> ModuleType:
     return _check_and_import(module='pandas', extra='csv')
 
 
-def get_distinctipy() -> ModuleType:
-    return _check_and_import(module='distinctipy', extra='plot')
+def get_colorcet() -> ModuleType:
+    return _check_and_import(module='colorcet', extra='plot')
 
 
 def get_ffmpeg() -> ModuleType:

--- a/src/torchio/visualization.py
+++ b/src/torchio/visualization.py
@@ -47,6 +47,7 @@ def rotate(image: np.ndarray, *, radiological: bool = True, n: int = -1) -> np.n
 
 def _create_categorical_colormap(
     data: torch.Tensor,
+    cmap_name: str = 'glasbey_light',
 ) -> tuple[ListedColormap, BoundaryNorm]:
     num_classes = int(data.max())
     mpl, _ = import_mpl_plt()
@@ -56,10 +57,11 @@ def _create_categorical_colormap(
         (1, 1, 1),  # white for class 1
     ]
     if num_classes > 1:
-        from .external.imports import get_distinctipy
+        from .external.imports import get_colorcet
 
-        distinctipy = get_distinctipy()
-        distinct_colors = distinctipy.get_colors(num_classes - 1, rng=0)
+        colorcet = get_colorcet()
+        cmap = getattr(colorcet.cm, cmap_name)
+        distinct_colors = cmap.colors[: num_classes - 1]
         colors.extend(distinct_colors)
     boundaries = np.arange(-0.5, num_classes + 1.5, 1)
     colormap = mpl.colors.ListedColormap(colors)

--- a/src/torchio/visualization.py
+++ b/src/torchio/visualization.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from itertools import cycle
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -47,7 +48,7 @@ def rotate(image: np.ndarray, *, radiological: bool = True, n: int = -1) -> np.n
 
 def _create_categorical_colormap(
     data: torch.Tensor,
-    cmap_name: str = 'glasbey_light',
+    cmap_name: str = 'glasbey_category10',
 ) -> tuple[ListedColormap, BoundaryNorm]:
     num_classes = int(data.max())
     mpl, _ = import_mpl_plt()
@@ -61,7 +62,8 @@ def _create_categorical_colormap(
 
         colorcet = get_colorcet()
         cmap = getattr(colorcet.cm, cmap_name)
-        distinct_colors = cmap.colors[: num_classes - 1]
+        color_cycle = cycle(cmap.colors)
+        distinct_colors = [next(color_cycle) for _ in range(num_classes - 1)]
         colors.extend(distinct_colors)
     boundaries = np.arange(-0.5, num_classes + 1.5, 1)
     colormap = mpl.colors.ListedColormap(colors)


### PR DESCRIPTION
`distinctipy` takes a long time to compute long colormaps (15 seconds for 256 colors), and `glasbey` takes a long time to import (could be almost a minute the first time).

[`colorcet`](https://colorcet.holoviz.org/user_guide/Categorical.html) has a few nice pre-computed categorical colormaps (length 256), so we can cycle through those quickly. `glasbey_category10` seems to be a nice default colormap, more distinct and definitely less strident than the previous one.

Before:

<img width="1589" height="752" alt="image" src="https://github.com/user-attachments/assets/5abc7b1f-5fb1-445e-aabe-ae9338282820" />

After:

<img width="1589" height="752" alt="image" src="https://github.com/user-attachments/assets/08258220-a232-483a-9714-a9c868ea77f0" />

Before:

<img width="1492" height="890" alt="image" src="https://github.com/user-attachments/assets/b6831478-ec2c-49f8-bd29-894bb233394a" />

After:

<img width="1492" height="890" alt="image" src="https://github.com/user-attachments/assets/216a3637-b340-4e7f-8fab-c6e785fb0ca1" />

Before:

<img width="1556" height="890" alt="image" src="https://github.com/user-attachments/assets/4e3911cc-f308-49ee-a08f-759e1b7c9876" />

After:

<img width="1556" height="890" alt="image" src="https://github.com/user-attachments/assets/c78c6d15-ad86-405a-a01c-e8e09f3545df" />

---

`glasbey_light` is nice for black backgrounds, but I find it less dintinct and the first colors are a bit harsh.

<img width="1589" height="752" alt="image" src="https://github.com/user-attachments/assets/35c777ca-d6ef-4cab-ab40-35ee243f3eae" />

<img width="1492" height="890" alt="image" src="https://github.com/user-attachments/assets/7e4b1de2-92f5-44f1-846d-c2115dcb89cf" />

<img width="1556" height="890" alt="image" src="https://github.com/user-attachments/assets/292f70af-8c90-4a09-b2e7-87ea2697bd1e" />
