### PR TITLE
Fix support for vmin/vmax when plotting

### DIFF
--- a/src/torchio/visualization.py
+++ b/src/torchio/visualization.py
@@ -146,8 +146,10 @@ def plot_volume(
             ]
         )
         p1, p2 = np.percentile(displayed_data, percentiles)
-        imshow_kwargs['vmin'] = p1
-        imshow_kwargs['vmax'] = p2
+        if 'vmin' not in imshow_kwargs:
+            imshow_kwargs['vmin'] = p1
+        if 'vmax' not in imshow_kwargs:
+            imshow_kwargs['vmax'] = p2
 
     spacing_r, spacing_a, spacing_s = image.spacing
     sag_axis, cor_axis, axi_axis = axes


### PR DESCRIPTION
Code:

```python
import torchio as tio

ct = tio.datasets.Slicer("CTChest").CT_chest
ct.plot()
ct.plot(vmin=-1000, vmax=1000)
```

Before:

<img width="1260" height="436" alt="image" src="https://github.com/user-attachments/assets/a65fe628-23a8-4fb0-9e7a-22b73db64dd1" />
<img width="1260" height="436" alt="image" src="https://github.com/user-attachments/assets/f1f52d95-4899-41e0-999f-a72666867d02" />

After:

<img width="1260" height="436" alt="image" src="https://github.com/user-attachments/assets/1c105f7f-7878-4de3-ae2a-d7ff7ebe6f66" />
<img width="1260" height="436" alt="image" src="https://github.com/user-attachments/assets/7df61787-4cd3-44b8-9e7c-9bcbb8652d2b" />
