### PR TITLE
Fix comment in `nib_to_sitk`

### DIFF
--- a/src/torchio/data/io.py
+++ b/src/torchio/data/io.py
@@ -318,7 +318,7 @@ def nib_to_sitk(
         array = array[..., 0]
     if not is_multichannel and not force_4d:
         array = array[0]
-    array = array.transpose()  # (W, H, D, C) or (W, H, D)
+    array = array.transpose()  # (D, H, W, C) or (H, W, C) or (D, H, W) or (H, W)
     image = sitk.GetImageFromArray(array, isVector=is_multichannel)
 
     origin, spacing, direction = get_sitk_metadata_from_ras_affine(


### PR DESCRIPTION
**Description**

<!-- Write a few sentences describing the changes proposed in this pull request. -->

I have updated a comment which I believe was confusing and misleading. On `torchio/data/io.py`, function `nib_to_sitk`, the shape that is provided in the comment next to `array.transpose()` does not agree with the shapes that are provided as possibilities at the beginning of the function.

**Checklist**

<!-- You do not need to complete all the items by the time you submit the pull
request, but most likely the changes will only be merged if all the tasks are
done. See more information about the submission process in the
CONTRIBUTING (https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.md) docs. -->

<!-- Write an `x` in all the boxes that apply -->
- [ ] I have read the [`CONTRIBUTING`](https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.md) docs and have a developer setup ready
- Changes are
  - [x] Non-breaking (would not break existing functionality)
  - [ ] Breaking (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] In-line docstrings updated
- [ ] Documentation updated
- [x] This pull request is ready to be reviewed
