### PR TITLE
Improve dataset docstrings and fix typo in datasets module

### DIFF
--- a/src/torchio/datasets/bite.py
+++ b/src/torchio/datasets/bite.py
@@ -42,7 +42,7 @@ class BITE(SubjectsDataset, abc.ABC):
 class BITE3(BITE):
     """Pre- and post-resection MR images in BITE.
 
-    *The goal of BITE is to share in vivo medical images of patients wtith
+    *The goal of BITE is to share in vivo medical images of patients with
     brain tumors to facilitate the development and validation of new image
     processing algorithms.*
 

--- a/src/torchio/datasets/itk_snap/itk_snap.py
+++ b/src/torchio/datasets/itk_snap/itk_snap.py
@@ -41,14 +41,14 @@ class BrainTumor(SubjectITKSNAP):
     plus a manual tumor segmentation label map, for a single subject from
     the BRATS dataset (case HG0015).
 
-    Keys: ``t1``, ``t1c``, ``t2``, ``flair``, ``seg``.
+    Keys: `t1`, `t1c`, `t2`, `flair`, `seg`.
 
-    Example::
+    Examples:
 
         >>> import torchio as tio
         >>> subject = tio.datasets.BrainTumor()
         >>> subject
-        Subject(Keys: ('t1', 't1c', 't2', 'flair', 'seg'); images: 5)
+        BrainTumor(Keys: ('t1', 't1c', 't2', 'flair', 'seg'); images: 5)
     """
 
     def __init__(self):
@@ -75,14 +75,14 @@ class T1T2(SubjectITKSNAP):
     T2-weighted MRI of the hippocampal region, intended for use with the
     ASHS-PMC distributed segmentation service.
 
-    Keys: ``mprage``, ``tse``.
+    Keys: `mprage`, `tse`.
 
-    Example::
+    Examples:
 
-        >> import torchio as tio
-        >> subject = tio.datasets.T1T2()
-        >> subject
-        Subject(Keys: ('mprage', 'tse'); images: 2)
+        >>> import torchio as tio
+        >>> subject = tio.datasets.T1T2()
+        >>> subject
+        T1T2(Keys: ('mprage', 'tse'); images: 2)
     """
 
     def __init__(self):
@@ -105,9 +105,9 @@ class AorticValve(SubjectITKSNAP):
     Intended as tutorial data for ITK-SNAP distributed segmentation service
     development.
 
-    Keys: ``b14``, ``b14_seg``, ``b25``, ``b25_seg``.
+    Keys: `b14`, `b14_seg`, `b25`, `b25_seg`.
 
-    Example::
+    Examples:
 
         >>> import torchio as tio
         >>> subject = tio.datasets.AorticValve()

--- a/src/torchio/datasets/itk_snap/itk_snap.py
+++ b/src/torchio/datasets/itk_snap/itk_snap.py
@@ -109,10 +109,10 @@ class AorticValve(SubjectITKSNAP):
 
     Example::
 
-        >>  import torchio as tio
-        >>  subject = tio.datasets.AorticValve()
-        >>  subject
-        Subject(Keys: ('b14', 'b14_seg', 'b25', 'b25_seg'); images: 4)
+        >>> import torchio as tio
+        >>> subject = tio.datasets.AorticValve()
+        >>> subject
+        AorticValve(Keys: ('b14', 'b14_seg', 'b25', 'b25_seg'); images: 4)
     """
 
     def __init__(self):

--- a/src/torchio/datasets/itk_snap/itk_snap.py
+++ b/src/torchio/datasets/itk_snap/itk_snap.py
@@ -35,6 +35,22 @@ class SubjectITKSNAP(Subject):
 
 
 class BrainTumor(SubjectITKSNAP):
+    """Multi-modal brain tumor MRI from the ITK-SNAP data downloads.
+
+    Contains T1, contrast-enhanced T1 (T1C), T2, and FLAIR scalar images,
+    plus a manual tumor segmentation label map, for a single subject from
+    the BRATS dataset (case HG0015).
+
+    Keys: ``t1``, ``t1c``, ``t2``, ``flair``, ``seg``.
+
+    Example::
+
+        >>> import torchio as tio
+        >>> subject = tio.datasets.BrainTumor()
+        >>> subject
+        Subject(Keys: ('t1', 't1c', 't2', 'flair', 'seg'); images: 5)
+    """
+
     def __init__(self):
         super().__init__('braintumor', '6161')
 
@@ -53,6 +69,22 @@ class BrainTumor(SubjectITKSNAP):
 
 
 class T1T2(SubjectITKSNAP):
+    """Hippocampal subfield segmentation test workspace from the ITK-SNAP data downloads.
+
+    Contains a whole-brain 3T T1-weighted MRI (MPRAGE) and a high-resolution
+    T2-weighted MRI of the hippocampal region, intended for use with the
+    ASHS-PMC distributed segmentation service.
+
+    Keys: ``mprage``, ``tse``.
+
+    Example::
+
+        >> import torchio as tio
+        >> subject = tio.datasets.T1T2()
+        >> subject
+        Subject(Keys: ('mprage', 'tse'); images: 2)
+    """
+    
     def __init__(self):
         super().__init__('ashs_test', '10983')
 
@@ -66,6 +98,22 @@ class T1T2(SubjectITKSNAP):
 
 
 class AorticValve(SubjectITKSNAP):
+    """Bicuspid aortic valve 3D ultrasound from the ITK-SNAP data downloads.
+
+    Contains two 3D frames (frames 14 and 25) from a bicuspid aortic valve
+    ultrasound scan, each paired with a manual segmentation label map.
+    Intended as tutorial data for ITK-SNAP distributed segmentation service
+    development.
+
+    Keys: ``b14``, ``b14_seg``, ``b25``, ``b25_seg``.
+
+    Example::
+
+        >>  import torchio as tio
+        >>  subject = tio.datasets.AorticValve()
+        >>  subject
+        Subject(Keys: ('b14', 'b14_seg', 'b25', 'b25_seg'); images: 4)
+    """
     def __init__(self):
         super().__init__('bav_example', '11021')
 

--- a/src/torchio/datasets/itk_snap/itk_snap.py
+++ b/src/torchio/datasets/itk_snap/itk_snap.py
@@ -84,7 +84,7 @@ class T1T2(SubjectITKSNAP):
         >> subject
         Subject(Keys: ('mprage', 'tse'); images: 2)
     """
-    
+
     def __init__(self):
         super().__init__('ashs_test', '10983')
 
@@ -114,6 +114,7 @@ class AorticValve(SubjectITKSNAP):
         >>  subject
         Subject(Keys: ('b14', 'b14_seg', 'b25', 'b25_seg'); images: 4)
     """
+
     def __init__(self):
         super().__init__('bav_example', '11021')
 

--- a/src/torchio/datasets/mni/sheep.py
+++ b/src/torchio/datasets/mni/sheep.py
@@ -16,11 +16,11 @@ class Sheep(SubjectMNI):
     anatomical and functional information across individual sheep and studies.
 
     More information can be found on the
-    `MNI Ovine Brain Atlas page <https://www.mcgill.ca/bic/neuroinformatics/brain-atlases-ovine-brain-atlas>`_.
+    [MNI Ovine Brain Atlas page](https://www.mcgill.ca/bic/neuroinformatics/brain-atlases-ovine-brain-atlas)`_.
 
-    Keys: ``t1``.
+    Keys: `t1`.
 
-    Example::
+    Examples:
 
         >>> import torchio as tio
         >>> subject = tio.datasets.Sheep()

--- a/src/torchio/datasets/mni/sheep.py
+++ b/src/torchio/datasets/mni/sheep.py
@@ -8,6 +8,26 @@ from .mni import SubjectMNI
 
 
 class Sheep(SubjectMNI):
+    """Population-averaged ovine brain MRI template from the MNI.
+
+    A stereotaxic, population-averaged T1-weighted brain template constructed
+    from 14 normal adult sheep (*Ovis orientalis aries*) at 0.5 mm isotropic
+    resolution. Provides a common stereotaxic reference frame for localizing
+    anatomical and functional information across individual sheep and studies.
+
+    More information can be found on the
+    `MNI Ovine Brain Atlas page <https://www.mcgill.ca/bic/neuroinformatics/brain-atlases-ovine-brain-atlas>`_.
+
+    Keys: ``t1``.
+
+    Example::
+
+        >>> import torchio as tio
+        >>> subject = tio.datasets.Sheep()
+        >>> subject
+        Sheep(Keys: ('t1',); images: 1)
+    """
+
     def __init__(self):
         self.name = 'NIFTI_ovine_05mm'
         self.url_dir = urllib.parse.urljoin(self.url_base, 'sheep/')

--- a/src/torchio/datasets/mni/sheep.py
+++ b/src/torchio/datasets/mni/sheep.py
@@ -16,8 +16,7 @@ class Sheep(SubjectMNI):
     anatomical and functional information across individual sheep and studies.
 
     More information can be found on the
-    [MNI Ovine Brain Atlas page](https://www.mcgill.ca/bic/neuroinformatics/brain-atlases-ovine-brain-atlas)`_.
-
+    [MNI Ovine Brain Atlas page](https://www.mcgill.ca/bic/neuroinformatics/brain-atlases-ovine-brain-atlas).
     Keys: `t1`.
 
     Examples:


### PR DESCRIPTION
**Description**

Fixed a typo (`wtith` → `with`) in `bite.py`
 added docstrings to four dataset classes that had none: `BrainTumor`, `T1T2`, and `AorticValve` in `itk_snap.py`, and `Sheep` in `mni/sheep.py`. Docstring content was sourced from the [ITK-SNAP data downloads page](http://www.itksnap.org/pmwiki/pmwiki.php?n=Downloads.Data) and the [MNI Ovine Brain Atlas page](https://www.mcgill.ca/bic/neuroinformatics/brain-atlases-ovine-brain-atlas). 
 Let me know if something else is needed since I went off the code and the source websites of the databases!
Fairly simple PR, was having a look at the code, so thought of contributing.

**Checklist**
- [x] I have read the [`CONTRIBUTING`](https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.md) docs and have a developer setup ready
- Changes are
  - [x] Non-breaking (would not break existing functionality)
  - [ ] Breaking (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [x] In-line docstrings updated
- [x] Documentation updated
- [x] This pull request is ready to be reviewed
