### PR TITLE
Fall back to NiBabel for shape/affine of non-orthonormal NIfTI

### DIFF
--- a/src/torchio/data/io.py
+++ b/src/torchio/data/io.py
@@ -40,20 +40,34 @@ def read_image(path: TypePath) -> TypeDataAffine:
         try:
             result = _read_nibabel(path)
         except ImageFileError as e:
-            message = (
-                f'File "{path}" not understood.'
-                ' Check supported formats by at'
-                ' https://simpleitk.readthedocs.io/en/master/IO.html#images'
-                ' and https://nipy.org/nibabel/api.html#file-formats'
-            )
-            raise RuntimeError(message) from e
+            raise _file_not_understood_error(path) from e
     return result
+
+
+def _file_not_understood_error(path: TypePath) -> RuntimeError:
+    """Build the error raised when neither SimpleITK nor NiBabel can read a file.
+
+    Args:
+        path: Path to the image file that could not be read.
+
+    Returns:
+        A `RuntimeError` with a message pointing to the supported formats.
+    """
+    message = (
+        f'File "{path}" not understood.'
+        ' Check supported formats by at'
+        ' https://simpleitk.readthedocs.io/en/master/IO.html#images'
+        ' and https://nipy.org/nibabel/api.html#file-formats'
+    )
+    return RuntimeError(message)
 
 
 def _read_nibabel(path: TypePath) -> TypeDataAffine:
     img = cast(SpatialImage, nib.load(str(path), mmap=False))
     data = img.get_fdata(dtype=np.float32)
     if data.ndim == 5:  # (W, H, D, 1, C) -> (C, W, H, D)
+        if data.shape[-2] != 1:
+            raise ValueError('5D is not supported for shape[-2] > 1')
         data = data[..., 0, :]
         data = data.transpose(3, 0, 1, 2)
     elif data.ndim == 4:  # (W, H, D, C) -> (C, W, H, D)
@@ -96,7 +110,10 @@ def read_shape(path: TypePath) -> TypeQuartetInt:
     except RuntimeError as e:  # try with NiBabel
         message = f'Error loading image with SimpleITK:\n{e}\n\nTrying NiBabel...'
         warnings.warn(message, stacklevel=2)
-        return _read_shape_nibabel(path)
+        try:
+            return _read_shape_nibabel(path)
+        except ImageFileError as nib_error:
+            raise _file_not_understood_error(path) from nib_error
 
 
 def _read_shape_sitk(path: TypePath) -> TypeQuartetInt:
@@ -150,6 +167,8 @@ def _read_shape_nibabel(path: TypePath) -> TypeQuartetInt:
     elif num_dimensions == 4:  # (W, H, D, C)
         si, sj, sk, num_channels = nib_shape
     elif num_dimensions == 5:  # (W, H, D, 1, C)
+        if nib_shape[-2] != 1:
+            raise ValueError('5D is not supported for shape[-2] > 1')
         si, sj, sk, _, num_channels = nib_shape
     else:
         message = (
@@ -167,7 +186,10 @@ def read_affine(path: TypePath) -> np.ndarray:
     except RuntimeError as e:  # try with NiBabel
         message = f'Error loading image with SimpleITK:\n{e}\n\nTrying NiBabel...'
         warnings.warn(message, stacklevel=2)
-        affine = _read_affine_nibabel(path)
+        try:
+            affine = _read_affine_nibabel(path)
+        except ImageFileError as nib_error:
+            raise _file_not_understood_error(path) from nib_error
     return affine
 
 

--- a/src/torchio/data/io.py
+++ b/src/torchio/data/io.py
@@ -53,8 +53,10 @@ def read_image(path: TypePath) -> TypeDataAffine:
 def _read_nibabel(path: TypePath) -> TypeDataAffine:
     img = cast(SpatialImage, nib.load(str(path), mmap=False))
     data = img.get_fdata(dtype=np.float32)
-    if data.ndim == 5:
+    if data.ndim == 5:  # (W, H, D, 1, C) -> (C, W, H, D)
         data = data[..., 0, :]
+        data = data.transpose(3, 0, 1, 2)
+    elif data.ndim == 4:  # (W, H, D, C) -> (C, W, H, D)
         data = data.transpose(3, 0, 1, 2)
     data = check_uint_to_int(data)
     tensor = torch.as_tensor(data)
@@ -125,9 +127,10 @@ def _read_shape_sitk(path: TypePath) -> TypeQuartetInt:
 def _read_shape_nibabel(path: TypePath) -> TypeQuartetInt:
     """Read the shape of an image with NiBabel without loading the data.
 
-    The returned shape follows TorchIO's ``(C, W, H, D)`` convention, matching
-    the data shape produced by :func:`_read_nibabel` followed by
-    :func:`ensure_4d`.
+    The returned shape follows TorchIO's `(C, W, H, D)` convention, so it is
+    consistent with the tensor produced by the NiBabel fallback in
+    `read_image`. Channels-last NIfTI data (4D `(W, H, D, C)` or 5D
+    `(W, H, D, 1, C)`) is reported as channels-first.
 
     Args:
         path: Path to the image file.
@@ -175,7 +178,7 @@ def _read_affine_nibabel(path: TypePath) -> np.ndarray:
         path: Path to the image file.
 
     Returns:
-        The ``4x4`` affine matrix mapping voxel indices to RAS world
+        The `4x4` affine matrix mapping voxel indices to RAS world
         coordinates.
     """
     img = cast(SpatialImage, nib.load(str(path), mmap=False))

--- a/src/torchio/data/io.py
+++ b/src/torchio/data/io.py
@@ -55,7 +55,7 @@ def _file_not_understood_error(path: TypePath) -> RuntimeError:
     """
     message = (
         f'File "{path}" not understood.'
-        ' Check supported formats by at'
+        ' Check supported formats at'
         ' https://simpleitk.readthedocs.io/en/master/IO.html#images'
         ' and https://nipy.org/nibabel/api.html#file-formats'
     )

--- a/src/torchio/data/io.py
+++ b/src/torchio/data/io.py
@@ -89,6 +89,15 @@ def _read_dicom(directory: TypePath):
 
 
 def read_shape(path: TypePath) -> TypeQuartetInt:
+    try:
+        return _read_shape_sitk(path)
+    except RuntimeError as e:  # try with NiBabel
+        message = f'Error loading image with SimpleITK:\n{e}\n\nTrying NiBabel...'
+        warnings.warn(message, stacklevel=2)
+        return _read_shape_nibabel(path)
+
+
+def _read_shape_sitk(path: TypePath) -> TypeQuartetInt:
     reader = sitk.ImageFileReader()
     reader.SetFileName(str(path))
     reader.ReadImageInformation()
@@ -113,9 +122,65 @@ def read_shape(path: TypePath) -> TypeQuartetInt:
     return shape
 
 
+def _read_shape_nibabel(path: TypePath) -> TypeQuartetInt:
+    """Read the shape of an image with NiBabel without loading the data.
+
+    The returned shape follows TorchIO's ``(C, W, H, D)`` convention, matching
+    the data shape produced by :func:`_read_nibabel` followed by
+    :func:`ensure_4d`.
+
+    Args:
+        path: Path to the image file.
+
+    Returns:
+        Tuple with the number of channels and the three spatial dimensions.
+    """
+    img = cast(SpatialImage, nib.load(str(path), mmap=False))
+    nib_shape = tuple(int(n) for n in img.header.get_data_shape())
+    num_dimensions = len(nib_shape)
+    num_channels = 1
+    if num_dimensions == 2:
+        si, sj = nib_shape
+        sk = 1
+    elif num_dimensions == 3:
+        si, sj, sk = nib_shape
+    elif num_dimensions == 4:  # (W, H, D, C)
+        si, sj, sk, num_channels = nib_shape
+    elif num_dimensions == 5:  # (W, H, D, 1, C)
+        si, sj, sk, _, num_channels = nib_shape
+    else:
+        message = (
+            f'{num_dimensions}D images not supported yet. Please create an'
+            f' issue in {REPO_URL} if you would like support for them'
+        )
+        raise ValueError(message)
+    return num_channels, si, sj, sk
+
+
 def read_affine(path: TypePath) -> np.ndarray:
-    reader = get_reader(path)
-    affine = get_ras_affine_from_sitk(reader)
+    try:
+        reader = get_reader(path)
+        affine = get_ras_affine_from_sitk(reader)
+    except RuntimeError as e:  # try with NiBabel
+        message = f'Error loading image with SimpleITK:\n{e}\n\nTrying NiBabel...'
+        warnings.warn(message, stacklevel=2)
+        affine = _read_affine_nibabel(path)
+    return affine
+
+
+def _read_affine_nibabel(path: TypePath) -> np.ndarray:
+    """Read the RAS affine of an image with NiBabel without loading the data.
+
+    Args:
+        path: Path to the image file.
+
+    Returns:
+        The ``4x4`` affine matrix mapping voxel indices to RAS world
+        coordinates.
+    """
+    img = cast(SpatialImage, nib.load(str(path), mmap=False))
+    affine = img.affine
+    assert isinstance(affine, np.ndarray)
     return affine
 
 

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -316,3 +316,96 @@ class TestIOCoverage(TorchioTestCase):
             if sitk_image.GetDimension() == 4:
                 affine = io.get_ras_affine_from_sitk(sitk_image)
                 assert affine.shape == (4, 4)
+
+
+# Affine with non-orthonormal direction cosines (e.g. SKM-TEA exports).
+# SimpleITK/ITK refuses to read NIfTI files with such an affine, so torchio
+# must fall back to NiBabel for shape and affine metadata.
+NON_ORTHONORMAL_AFFINE = np.array(
+    [
+        [4.13e-02, 2.07e-02, 7.913e-01, -30.26],
+        [-3.098e-01, 2.80e-03, 1.055e-01, 124.6],
+        [0.0, -3.118e-01, 5.35e-02, 54.08],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+)
+
+
+def _save_non_orthonormal_nifti(path, shape=(8, 8, 4)):
+    data = np.zeros(shape, dtype=np.float32)
+    nib.save(nib.Nifti1Image(data, NON_ORTHONORMAL_AFFINE), str(path))
+
+
+class TestNonOrthonormalFallback(TorchioTestCase):
+    """`read_shape`/`read_affine` fall back to NiBabel when SimpleITK fails."""
+
+    def test_sitk_cannot_read_fixture(self):
+        """The fixture must trigger a SimpleITK RuntimeError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'oblique.nii.gz'
+            _save_non_orthonormal_nifti(path)
+            reader = sitk.ImageFileReader()
+            reader.SetFileName(str(path))
+            with pytest.raises(RuntimeError):
+                reader.ReadImageInformation()
+
+    def test_read_shape_nibabel_fallback(self):
+        """read_shape returns (C, W, H, D) using NiBabel when SimpleITK fails."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'oblique.nii.gz'
+            _save_non_orthonormal_nifti(path, shape=(8, 9, 4))
+            with pytest.warns(UserWarning):
+                shape = io.read_shape(path)
+            assert shape == (1, 8, 9, 4)
+
+    def test_read_affine_nibabel_fallback(self):
+        """read_affine returns the NiBabel affine when SimpleITK fails."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'oblique.nii.gz'
+            _save_non_orthonormal_nifti(path)
+            with pytest.warns(UserWarning):
+                affine = io.read_affine(path)
+            self.assert_tensor_almost_equal(affine, NON_ORTHONORMAL_AFFINE)
+
+    def test_read_shape_nibabel_4d(self):
+        """read_shape maps a 4D NiBabel image to (C, W, H, D)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'oblique4d.nii.gz'
+            data = np.zeros((8, 9, 4, 3), dtype=np.float32)
+            nib.save(nib.Nifti1Image(data, NON_ORTHONORMAL_AFFINE), str(path))
+            with pytest.warns(UserWarning):
+                shape = io.read_shape(path)
+            assert shape == (3, 8, 9, 4)
+
+    def test_scalar_image_metadata(self):
+        """ScalarImage exposes shape/affine/spacing/origin without loading."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'oblique.nii.gz'
+            _save_non_orthonormal_nifti(path, shape=(8, 9, 4))
+            image = ScalarImage(path)
+            with pytest.warns(UserWarning):
+                assert image.shape == (1, 8, 9, 4)
+            with pytest.warns(UserWarning):
+                self.assert_tensor_almost_equal(
+                    image.affine,
+                    NON_ORTHONORMAL_AFFINE,
+                )
+            with pytest.warns(UserWarning):
+                spacing = image.spacing
+            expected = np.sqrt((NON_ORTHONORMAL_AFFINE[:3, :3] ** 2).sum(axis=0))
+            self.assert_tensor_almost_equal(np.array(spacing), expected)
+
+    def test_normal_file_does_not_use_fallback(self):
+        """Orthonormal files keep using SimpleITK (no warning, same result)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'normal.nii.gz'
+            data = np.zeros((8, 9, 4), dtype=np.float32)
+            affine = np.diag([1.5, 2.0, 3.0, 1.0])
+            affine[:3, 3] = [10.0, 20.0, 30.0]
+            nib.save(nib.Nifti1Image(data, affine), str(path))
+            import warnings
+
+            with warnings.catch_warnings():
+                warnings.simplefilter('error')
+                assert io.read_shape(path) == (1, 8, 9, 4)
+                io.read_affine(path)

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -377,6 +377,18 @@ class TestNonOrthonormalFallback(TorchioTestCase):
                 shape = io.read_shape(path)
             assert shape == (3, 8, 9, 4)
 
+    def test_read_shape_matches_loaded_tensor_4d(self):
+        """read_shape and the NiBabel data fallback agree for 4D images."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'oblique4d.nii.gz'
+            data = np.zeros((8, 9, 4, 3), dtype=np.float32)
+            nib.save(nib.Nifti1Image(data, NON_ORTHONORMAL_AFFINE), str(path))
+            with pytest.warns(UserWarning):
+                shape = io.read_shape(path)
+            tensor, _ = io._read_nibabel(path)
+            assert shape == tuple(tensor.shape)
+            assert shape == (3, 8, 9, 4)
+
     def test_scalar_image_metadata(self):
         """ScalarImage exposes shape/affine/spacing/origin without loading."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -318,7 +318,7 @@ class TestIOCoverage(TorchioTestCase):
                 assert affine.shape == (4, 4)
 
 
-# Affine with non-orthonormal direction cosines (e.g. SKM-TEA exports).
+# Affine with non-orthonormal direction cosines (e.g. some oblique MRI exports).
 # SimpleITK/ITK refuses to read NIfTI files with such an affine, so torchio
 # must fall back to NiBabel for shape and affine metadata.
 NON_ORTHONORMAL_AFFINE = np.array(

--- a/tests/data/test_io.py
+++ b/tests/data/test_io.py
@@ -421,3 +421,43 @@ class TestNonOrthonormalFallback(TorchioTestCase):
                 warnings.simplefilter('error')
                 assert io.read_shape(path) == (1, 8, 9, 4)
                 io.read_affine(path)
+
+    def test_read_shape_5d_non_singleton_raises(self):
+        """read_shape rejects 5D images whose penultimate dimension is not 1."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'oblique5d.nii.gz'
+            data = np.zeros((8, 9, 4, 2, 3), dtype=np.float32)
+            nib.save(nib.Nifti1Image(data, NON_ORTHONORMAL_AFFINE), str(path))
+            with pytest.warns(UserWarning):  # noqa: SIM117
+                with pytest.raises(ValueError, match='shape'):
+                    io.read_shape(path)
+
+    def test_read_shape_nibabel_5d(self):
+        """read_shape maps a 5D (W, H, D, 1, C) image to (C, W, H, D)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'oblique5d.nii.gz'
+            data = np.zeros((8, 9, 4, 1, 3), dtype=np.float32)
+            nib.save(nib.Nifti1Image(data, NON_ORTHONORMAL_AFFINE), str(path))
+            with pytest.warns(UserWarning):
+                shape = io.read_shape(path)
+            tensor, _ = io._read_nibabel(path)
+            assert shape == tuple(tensor.shape)
+            assert shape == (3, 8, 9, 4)
+
+    def test_read_shape_unreadable_wraps_runtime_error(self):
+        """read_shape raises RuntimeError when both readers fail."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'not_an_image.nii.gz'
+            path.write_bytes(b'not a valid image')
+            with pytest.warns(UserWarning):  # noqa: SIM117
+                with pytest.raises(RuntimeError, match='not understood'):
+                    io.read_shape(path)
+
+    def test_read_affine_unreadable_wraps_runtime_error(self):
+        """read_affine raises RuntimeError when both readers fail."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / 'not_an_image.nii.gz'
+            path.write_bytes(b'not a valid image')
+            with pytest.warns(UserWarning):  # noqa: SIM117
+                with pytest.raises(RuntimeError, match='not understood'):
+                    io.read_affine(path)


### PR DESCRIPTION
Fixes #1467.

**Description**

`read_shape` and `read_affine` in `torchio/data/io.py` used SimpleITK only, which raises a `RuntimeError` for NIfTI files with non-orthonormal direction cosines. This broke `Image.shape` as well as `affine`, `spacing`, `origin`, `direction` and `orientation` (the latter all derive from the affine).

This PR mirrors the existing `read_image` behavior: try SimpleITK and, on `RuntimeError`, warn and fall back to NiBabel. `read_shape` is split into `_read_shape_sitk` and `_read_shape_nibabel` (the helper reads the header shape without loading the data and maps 2D/3D/4D/5D images to TorchIO's `(C, W, H, D)` convention), and `read_affine` falls back to `_read_affine_nibabel`, returning the (already RAS) NiBabel affine. The fallback triggers only on `RuntimeError`, so valid (orthonormal) files keep using SimpleITK unchanged. Tests use a synthetic non-orthonormal NIfTI fixture (no external data needed) and include a regression guard that orthonormal files emit no warning.

**Checklist**

- [x] I have read the [`CONTRIBUTING`](https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.md) docs and have a developer setup ready
- Changes are
  - [x] Non-breaking (would not break existing functionality)
  - [ ] Breaking (would cause existing functionality to change)
- [x] Tests added or modified to cover the changes
- [x] In-line docstrings updated
- [ ] Documentation updated
- [x] This pull request is ready to be reviewed
