### PR TITLE
Fix invalid-overload type error in WeightedSampler.extract_patch

### DIFF
--- a/src/torchio/data/sampler/weighted.py
+++ b/src/torchio/data/sampler/weighted.py
@@ -193,32 +193,34 @@ class WeightedSampler(RandomSampler):
         subject: Subject,
         probability_map: np.ndarray,
         cdf: np.ndarray,
+        /,
     ) -> Subject: ...
 
     def extract_patch(
         self,
         subject: Subject,
-        index_ini_or_probability_map: TypeTripletInt | np.ndarray,
+        index_ini: TypeTripletInt | np.ndarray,
         cdf: np.ndarray | None = None,
     ) -> Subject:
         if cdf is None:
-            if isinstance(index_ini_or_probability_map, np.ndarray):
-                index_ini = (
-                    int(index_ini_or_probability_map[0]),
-                    int(index_ini_or_probability_map[1]),
-                    int(index_ini_or_probability_map[2]),
+            if isinstance(index_ini, np.ndarray):
+                index_ini_tuple = (
+                    int(index_ini[0]),
+                    int(index_ini[1]),
+                    int(index_ini[2]),
                 )
             else:
-                index_ini = index_ini_or_probability_map
-            return super().extract_patch(subject, index_ini)
+                index_ini_tuple = index_ini
+            return super().extract_patch(subject, index_ini_tuple)
 
-        if not isinstance(index_ini_or_probability_map, np.ndarray):
+        if not isinstance(index_ini, np.ndarray):
             message = 'Probability map must be a NumPy array when using a CDF'
             raise TypeError(message)
 
-        i, j, k = self.get_random_index_ini(index_ini_or_probability_map, cdf)
-        index_ini = i, j, k
-        return super().extract_patch(subject, index_ini)
+        probability_map = index_ini
+        i, j, k = self.get_random_index_ini(probability_map, cdf)
+        index_ini_tuple = i, j, k
+        return super().extract_patch(subject, index_ini_tuple)
 
     def get_random_index_ini(
         self,


### PR DESCRIPTION
## Summary

Fixes the `types` CI job (`ty check src`), which fails on Python ≥3.11 with:

```
src/torchio/data/sampler/weighted.py:183:9: error[invalid-overload] Implementation does not accept all arguments of this overload
src/torchio/data/sampler/weighted.py:191:9: error[invalid-overload] Implementation does not accept all arguments of this overload
```

Closes #1469.

## Root cause

`WeightedSampler.extract_patch` declared two `@overload`s whose second parameter was named `index_ini` / `probability_map`, while the implementation named it `index_ini_or_probability_map`. As these are positional-or-keyword parameters, a keyword call matching an overload would not be accepted by the implementation, which `ty` reports as `invalid-overload`.

It only shows up on Python ≥3.11 because `uv.lock` is not committed and the `types` job resolves **numpy 2.4.6** there (numpy 2.4 requires Python ≥3.11), whose stricter `ndarray` stubs make `ty` evaluate the overloads. On Python 3.10 numpy resolves to 2.2.6 and the diagnostic stays hidden.

## Fix

- Rename the implementation's union parameter to `index_ini`, so it matches the first overload **and** the `PatchSampler.extract_patch` base method (keeping the override compatible).
- Make the probability-map overload positional-only (`/`) so its descriptive `probability_map` name is preserved as public API documentation without constraining the implementation.
- Use a separate local (`index_ini_tuple`) for the computed triplet to avoid shadowing.

No behavioural change; the only internal caller already passes the arguments positionally.

## Testing

Reproduced the failure locally with Python 3.12 + numpy 2.4.6 + ty 0.0.42, confirmed the fix resolves it, and ran the full `tox` suite:

- `pytest`: 832 passed
- `types` (`ty check src`): passed
- `lint` / `format` (ruff): passed