### PR TITLE
Vectorize all per-instance batch transforms

### DIFF
--- a/src/torchio/transforms/intensity/bias_field.py
+++ b/src/torchio/transforms/intensity/bias_field.py
@@ -223,22 +223,74 @@ def _apply_bias_per_element(
     Returns:
         The corrected `(B, C, I, J, K)` tensor.
     """
-    outputs = []
-    for index in range(data.shape[0]):
-        slice_b = data[index : index + 1]
-        if std_per_element[index] == 0:
-            outputs.append(slice_b)
-            continue
-        field = _generate_bias_field(
-            slice_b.shape,
-            std=std_per_element[index],
-            scale=scale,
-            seed=seed_per_element[index],
+    identity_rows = [std == 0 for std in std_per_element]
+    if all(identity_rows):
+        return data
+
+    coarse_field = _sample_coarse_bias_fields(
+        data.shape,
+        std_per_element=std_per_element,
+        seed_per_element=seed_per_element,
+        scale=scale,
+        device=data.device,
+    )
+    field = functional.interpolate(
+        coarse_field,
+        size=list(data.shape[2:]),
+        mode="trilinear",
+        align_corners=True,
+    )
+    field = torch.exp(field)
+    corrected = data / field if divide else data * field
+    corrected = corrected.to(data.dtype)
+
+    if any(identity_rows):
+        identity_mask = torch.tensor(
+            identity_rows,
+            dtype=torch.bool,
             device=data.device,
         )
-        corrected = slice_b / field if divide else slice_b * field
-        outputs.append(corrected.to(data.dtype))
-    return torch.cat(outputs, dim=0)
+        corrected[identity_mask] = data[identity_mask]
+
+    return corrected
+
+
+def _sample_coarse_bias_fields(
+    shape: tuple[int, ...],
+    *,
+    std_per_element: list[float],
+    seed_per_element: list[int],
+    scale: float,
+    device: torch.device,
+) -> Tensor:
+    """Sample per-element coarse bias fields before batched upsampling.
+
+    Args:
+        shape: `(B, C, I, J, K)` tensor shape.
+        std_per_element: Per-element standard deviations.
+        seed_per_element: Per-element random seeds.
+        scale: Ratio between the coarse field and the spatial shape.
+        device: Device to move the stacked coarse fields to.
+
+    Returns:
+        `(B, C, small_I, small_J, small_K)` tensor sampled from each
+            element's own seeded CPU generator.
+    """
+    channels = shape[1]
+    spatial = shape[2:]
+    small_shape = [max(round(s * scale), 4) for s in spatial]
+    coarse_fields = []
+    for std, seed in zip(std_per_element, seed_per_element, strict=True):
+        generator = torch.Generator(device="cpu")
+        generator.manual_seed(seed)
+        coarse_field = torch.normal(
+            mean=0.0,
+            std=std,
+            size=(1, channels, *small_shape),
+            generator=generator,
+        )
+        coarse_fields.append(coarse_field)
+    return torch.cat(coarse_fields, dim=0).to(device)
 
 
 def _generate_bias_field(

--- a/src/torchio/transforms/intensity/blur.py
+++ b/src/torchio/transforms/intensity/blur.py
@@ -182,9 +182,12 @@ def _gaussian_smooth_shared(
         kernel_1d = torch.exp(-0.5 * (x / sigma) ** 2)
         kernel_1d = kernel_1d / kernel_1d.sum()
 
-        k_shape = [1, 1, 1]
-        k_shape[axis_idx] = kernel_size
-        kernel_3d = kernel_1d.reshape(1, 1, *k_shape)
+        kernel_patterns = (
+            "k -> 1 1 k 1 1",
+            "k -> 1 1 1 k 1",
+            "k -> 1 1 1 1 k",
+        )
+        kernel_3d = rearrange(kernel_1d, kernel_patterns[axis_idx])
 
         pad = [0] * 6
         pad_idx = 2 * (2 - axis_idx)

--- a/src/torchio/transforms/intensity/blur.py
+++ b/src/torchio/transforms/intensity/blur.py
@@ -141,11 +141,64 @@ def _gaussian_smooth(
         Smoothed tensor.
     """
     sigmas_array = np.asarray(sigmas, dtype=np.float64)
-    if sigmas_array.ndim == 1:
-        sigmas_array = np.broadcast_to(sigmas_array, (data.shape[0], 3)).copy()
     if np.all(sigmas_array <= 0):
         return data
+    if sigmas_array.ndim == 1:
+        # Sigmas shared across the batch: build one kernel set and apply it
+        # to every element, which is much cheaper than a grouped conv.
+        return _gaussian_smooth_shared(data, sigmas_array)
+    if np.all(sigmas_array == sigmas_array[0]):
+        # Per-element sigmas that happen to be identical collapse to the
+        # shared fast path.
+        return _gaussian_smooth_shared(data, sigmas_array[0])
     return _gaussian_smooth_per_element(data, sigmas_array)
+
+
+def _gaussian_smooth_shared(
+    data: torch.Tensor,
+    sigmas: np.ndarray,
+) -> torch.Tensor:
+    """Separable Gaussian smoothing with a single shared kernel set.
+
+    Args:
+        data: `(B, C, I, J, K)` tensor.
+        sigmas: Per-axis sigma in voxels (length 3), shared by every
+            batch element.
+
+    Returns:
+        Smoothed tensor (input dtype preserved).
+    """
+    if np.all(sigmas <= 0):
+        return data
+    result = data.float()
+    b, c = result.shape[:2]
+    for axis_idx in range(3):
+        sigma = float(sigmas[axis_idx])
+        if sigma <= 0:
+            continue
+        radius = max(int(np.ceil(3 * sigma)), 1)
+        kernel_size = 2 * radius + 1
+        x = torch.arange(kernel_size, dtype=torch.float32, device=data.device) - radius
+        kernel_1d = torch.exp(-0.5 * (x / sigma) ** 2)
+        kernel_1d = kernel_1d / kernel_1d.sum()
+
+        k_shape = [1, 1, 1]
+        k_shape[axis_idx] = kernel_size
+        kernel_3d = kernel_1d.reshape(1, 1, *k_shape)
+
+        pad = [0] * 6
+        pad_idx = 2 * (2 - axis_idx)
+        pad[pad_idx] = radius
+        pad[pad_idx + 1] = radius
+
+        padded = functional.pad(result, pad, mode="replicate")
+        result = functional.conv3d(
+            rearrange(padded, "b c i j k -> (b c) 1 i j k"),
+            kernel_3d,
+            padding=0,
+        )
+        result = rearrange(result, "(b c) 1 i j k -> b c i j k", b=b, c=c)
+    return result.to(data.dtype)
 
 
 def _gaussian_smooth_per_element(

--- a/src/torchio/transforms/intensity/blur.py
+++ b/src/torchio/transforms/intensity/blur.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 import torch.nn.functional as functional
 from einops import rearrange
+from einops import repeat
 
 from ...data.batch import ImagesBatch
 from ...data.batch import SubjectsBatch
@@ -111,41 +112,68 @@ def _blur_per_element(
         The blurred `(B, C, I, J, K)` tensor.
     """
     data = img_batch.data
-    outputs = []
-    for index in range(data.shape[0]):
-        spacing = np.asarray(img_batch.affines[index].spacing, dtype=np.float64)
-        sigmas_vox = _sigmas_mm_to_voxels(sigmas_mm_per_element[index], spacing)
-        outputs.append(_gaussian_smooth(data[index : index + 1], sigmas_vox))
-    return torch.cat(outputs, dim=0)
+    sigmas_mm = np.asarray(sigmas_mm_per_element, dtype=np.float64)
+    spacings = np.asarray(
+        [affine.spacing for affine in img_batch.affines],
+        dtype=np.float64,
+    )
+    sigmas_vox = np.divide(
+        sigmas_mm,
+        spacings,
+        out=np.zeros_like(sigmas_mm),
+        where=spacings > 0,
+    )
+    return _gaussian_smooth(data, sigmas_vox)
 
 
-def _gaussian_smooth(data: torch.Tensor, sigmas: list[float]) -> torch.Tensor:
+def _gaussian_smooth(
+    data: torch.Tensor,
+    sigmas: list[float] | np.ndarray,
+) -> torch.Tensor:
     """Apply separable Gaussian smoothing to a 5D tensor.
 
     Args:
         data: `(B, C, I, J, K)` tensor.
-        sigmas: Per-axis sigma in voxels.
+        sigmas: Per-axis sigma in voxels, or per-element per-axis sigmas
+            with shape `(B, 3)`. Zero means skip that axis.
 
     Returns:
         Smoothed tensor.
     """
-    if all(s <= 0 for s in sigmas):
+    sigmas_array = np.asarray(sigmas, dtype=np.float64)
+    if sigmas_array.ndim == 1:
+        sigmas_array = np.broadcast_to(sigmas_array, (data.shape[0], 3)).copy()
+    if np.all(sigmas_array <= 0):
         return data
+    return _gaussian_smooth_per_element(data, sigmas_array)
+
+
+def _gaussian_smooth_per_element(
+    data: torch.Tensor,
+    sigmas: np.ndarray,
+) -> torch.Tensor:
+    """Apply Gaussian smoothing with per-element sigmas.
+
+    Args:
+        data: `(B, C, I, J, K)` tensor.
+        sigmas: Per-element per-axis sigmas in voxels with shape `(B, 3)`.
+
+    Returns:
+        Smoothed tensor with the same dtype as `data`.
+    """
     result = data.float()
     b, c = result.shape[:2]
+    no_blur_rows = np.all(sigmas <= 0, axis=1)
     for axis_idx in range(3):
-        sigma = sigmas[axis_idx]
-        if sigma <= 0:
+        axis_sigmas = sigmas[:, axis_idx]
+        if np.all(axis_sigmas <= 0):
             continue
-        radius = max(int(np.ceil(3 * sigma)), 1)
-        kernel_size = 2 * radius + 1
-        x = torch.arange(kernel_size, dtype=torch.float32, device=data.device) - radius
-        kernel_1d = torch.exp(-0.5 * (x / sigma) ** 2)
-        kernel_1d = kernel_1d / kernel_1d.sum()
-
-        k_shape = [1, 1, 1]
-        k_shape[axis_idx] = kernel_size
-        kernel_3d = kernel_1d.reshape(1, 1, *k_shape).expand(1, 1, -1, -1, -1)
+        kernel_3d, radius = _make_grouped_axis_kernel(
+            axis_sigmas,
+            axis_idx,
+            c,
+            data.device,
+        )
 
         # Replicate-pad along the target axis.
         pad = [0] * 6
@@ -155,9 +183,90 @@ def _gaussian_smooth(data: torch.Tensor, sigmas: list[float]) -> torch.Tensor:
 
         padded = functional.pad(result, pad, mode="replicate")
         result = functional.conv3d(
-            rearrange(padded, "b c i j k -> (b c) 1 i j k"),
+            rearrange(padded, "b c i j k -> 1 (b c) i j k"),
             kernel_3d,
+            groups=b * c,
             padding=0,
         )
-        result = rearrange(result, "(b c) 1 i j k -> b c i j k", b=b, c=c)
-    return result.to(data.dtype)
+        result = rearrange(result, "1 (b c) i j k -> b c i j k", b=b, c=c)
+    result = result.to(data.dtype)
+    if no_blur_rows.any():
+        no_blur_mask = torch.as_tensor(no_blur_rows, device=data.device)
+        result[no_blur_mask] = data[no_blur_mask]
+    return result
+
+
+def _make_grouped_axis_kernel(
+    sigmas: np.ndarray,
+    axis_idx: int,
+    channels: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, int]:
+    """Build one grouped 3D convolution kernel for one spatial axis.
+
+    Args:
+        sigmas: Per-element sigma in voxels for the target axis.
+        axis_idx: Spatial axis index, from 0 to 2.
+        channels: Number of image channels per batch element.
+        device: Device on which the kernel should be allocated.
+
+    Returns:
+        The `(B * C, 1, kI, kJ, kK)` grouped convolution kernel and the
+            maximum radius used to pad the input.
+    """
+    radii = np.zeros_like(sigmas, dtype=np.int64)
+    positive = sigmas > 0
+    radii[positive] = np.maximum(np.ceil(3 * sigmas[positive]).astype(np.int64), 1)
+    max_radius = int(radii.max())
+    kernel_1d = _make_stacked_1d_kernels(sigmas, radii, max_radius, device)
+    if axis_idx == 0:
+        kernel_3d = rearrange(kernel_1d, "b i -> b 1 i 1 1")
+    elif axis_idx == 1:
+        kernel_3d = rearrange(kernel_1d, "b j -> b 1 1 j 1")
+    else:
+        kernel_3d = rearrange(kernel_1d, "b k -> b 1 1 1 k")
+    kernel_3d = repeat(
+        kernel_3d,
+        "b one i j k -> (b c) one i j k",
+        c=channels,
+    )
+    return kernel_3d, max_radius
+
+
+def _make_stacked_1d_kernels(
+    sigmas: np.ndarray,
+    radii: np.ndarray,
+    max_radius: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build centered 1D Gaussian or identity kernels.
+
+    Args:
+        sigmas: Per-element sigma in voxels for one axis.
+        radii: Per-element kernel radii.
+        max_radius: Maximum radius across all elements for the axis.
+        device: Device on which the kernels should be allocated.
+
+    Returns:
+        A `(B, 2 * max_radius + 1)` tensor of normalized 1D kernels.
+    """
+    kernel_size = 2 * max_radius + 1
+    offsets = torch.arange(kernel_size, dtype=torch.float32, device=device) - max_radius
+    sigmas_tensor = torch.as_tensor(sigmas, dtype=torch.float32, device=device)
+    radii_tensor = torch.as_tensor(radii, device=device)
+    offsets_row = rearrange(offsets, "k -> 1 k")
+    sigmas_column = rearrange(sigmas_tensor, "b -> b 1")
+    radii_column = rearrange(radii_tensor, "b -> b 1")
+    safe_sigmas = torch.where(
+        sigmas_column > 0,
+        sigmas_column,
+        torch.ones_like(sigmas_column),
+    )
+    kernels = torch.exp(-0.5 * (offsets_row / safe_sigmas) ** 2)
+    within_radius = torch.abs(offsets_row) <= radii_column
+    kernels = torch.where(within_radius, kernels, torch.zeros_like(kernels))
+
+    delta = torch.zeros_like(kernels)
+    delta[:, max_radius] = 1.0
+    kernels = torch.where(sigmas_column > 0, kernels, delta)
+    return kernels / kernels.sum(dim=1, keepdim=True)

--- a/src/torchio/transforms/intensity/ghosting.py
+++ b/src/torchio/transforms/intensity/ghosting.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import torch
+from einops import rearrange
 from torch import Tensor
 
 from ...data.batch import SubjectsBatch
@@ -194,9 +195,15 @@ def _add_ghosting_per_element(
             half_restore = max(int(size * restore / 2), 1)
             lo, hi = mid - half_restore, mid + half_restore
             line_mask[lo:hi] = 1
-        shape = [1] * 5
-        shape[fft_dim] = size
-        mask[batch_index : batch_index + 1] = line_mask.reshape(*shape)
+        line_patterns = {
+            2: "s -> 1 1 s 1 1",
+            3: "s -> 1 1 1 s 1",
+            4: "s -> 1 1 1 1 s",
+        }
+        mask[batch_index : batch_index + 1] = rearrange(
+            line_mask,
+            line_patterns[fft_dim],
+        )
 
     corrupted = spectrum * mask
     result = torch.fft.ifftn(
@@ -204,7 +211,7 @@ def _add_ghosting_per_element(
         dim=(-3, -2, -1),
     ).real
     result = result.to(data.dtype)
-    active = active.reshape(-1, 1, 1, 1, 1)
+    active = rearrange(active, "b -> b 1 1 1 1")
     return torch.where(active, result, data)
 
 
@@ -246,9 +253,12 @@ def _add_ghosting(
     mask[::step] = 1 - intensity
 
     # Reshape mask for broadcasting: (1, 1, 1, 1, 1) with size at fft_dim.
-    shape = [1] * 5
-    shape[fft_dim] = size
-    mask = mask.reshape(*shape)
+    mask_patterns = {
+        2: "s -> 1 1 s 1 1",
+        3: "s -> 1 1 1 s 1",
+        4: "s -> 1 1 1 1 s",
+    }
+    mask = rearrange(mask, mask_patterns[fft_dim])
     corrupted = spectrum * mask
 
     # Restore the center of k-space.

--- a/src/torchio/transforms/intensity/ghosting.py
+++ b/src/torchio/transforms/intensity/ghosting.py
@@ -85,8 +85,8 @@ class Ghosting(IntensityTransform):
         num_ghosts_list: list[int] = []
         axis_list: list[int] = []
         intensity_list: list[float] = []
-        for index in range(n):
-            if keep is not None and not keep[index]:
+        for batch_index in range(n):
+            if keep is not None and not keep[batch_index]:
                 num_ghosts_list.append(0)
                 axis_list.append(self.axes[0])
                 intensity_list.append(0.0)
@@ -127,18 +127,13 @@ class Ghosting(IntensityTransform):
         restore = params["restore"]
         for _name, img_batch in self._get_images(batch).items():
             if per_instance:
-                data = img_batch.data
-                outputs = [
-                    _add_ghosting(
-                        data[index : index + 1],
-                        num_ghosts=params["num_ghosts"][index],
-                        axis=params["axis"][index],
-                        intensity=params["intensity"][index],
-                        restore=restore,
-                    )
-                    for index in range(data.shape[0])
-                ]
-                img_batch.data = torch.cat(outputs, dim=0)
+                img_batch.data = _add_ghosting_per_element(
+                    img_batch.data,
+                    num_ghosts=params["num_ghosts"],
+                    axis=params["axis"],
+                    intensity=params["intensity"],
+                    restore=restore,
+                )
             else:
                 img_batch.data = _add_ghosting(
                     img_batch.data,
@@ -148,6 +143,69 @@ class Ghosting(IntensityTransform):
                     restore=restore,
                 )
         return batch
+
+
+def _add_ghosting_per_element(
+    data: Tensor,
+    *,
+    num_ghosts: list[int],
+    axis: list[int],
+    intensity: list[float],
+    restore: float,
+) -> Tensor:
+    """Add ghosting with independent parameters for each batch element.
+
+    Args:
+        data: `(B, C, I, J, K)` image tensor.
+        num_ghosts: Number of ghost replicas per batch element.
+        axis: Spatial axis per batch element.
+        intensity: Artifact strength per batch element.
+        restore: Fraction of central k-space to restore.
+
+    Returns:
+        Corrupted `(B, C, I, J, K)` tensor.
+    """
+    result = data.float()
+    spectrum = torch.fft.fftshift(
+        torch.fft.fftn(result, dim=(-3, -2, -1)),
+        dim=(-3, -2, -1),
+    )
+    mask = torch.ones(
+        data.shape[0],
+        1,
+        *data.shape[2:],
+        dtype=result.dtype,
+        device=data.device,
+    )
+    active = torch.zeros(data.shape[0], dtype=torch.bool, device=data.device)
+    for batch_index, (ghosts, phase_axis, strength) in enumerate(
+        zip(num_ghosts, axis, intensity, strict=True)
+    ):
+        if not ghosts or strength == 0:
+            continue
+        active[batch_index] = True
+        fft_dim = phase_axis + 2
+        size = result.shape[fft_dim]
+        line_mask = torch.ones(size, dtype=result.dtype, device=data.device)
+        step = max(size // ghosts, 1)
+        line_mask[::step] = 1 - strength
+        if restore > 0:
+            mid = size // 2
+            half_restore = max(int(size * restore / 2), 1)
+            lo, hi = mid - half_restore, mid + half_restore
+            line_mask[lo:hi] = 1
+        shape = [1] * 5
+        shape[fft_dim] = size
+        mask[batch_index : batch_index + 1] = line_mask.reshape(*shape)
+
+    corrupted = spectrum * mask
+    result = torch.fft.ifftn(
+        torch.fft.ifftshift(corrupted, dim=(-3, -2, -1)),
+        dim=(-3, -2, -1),
+    ).real
+    result = result.to(data.dtype)
+    active = active.reshape(-1, 1, 1, 1, 1)
+    return torch.where(active, result, data)
 
 
 def _add_ghosting(

--- a/src/torchio/transforms/intensity/labels_to_image.py
+++ b/src/torchio/transforms/intensity/labels_to_image.py
@@ -193,15 +193,73 @@ def _generate_per_element(
     Returns:
         `(B, 1, I, J, K)` synthetic image tensor.
     """
-    outputs = [
-        _generate_from_labels(
-            label_data[index : index + 1],
-            means_per_element[index],
-            stds_per_element[index],
+    b = label_data.shape[0]
+    spatial = label_data.shape[2:]
+    result = torch.zeros(b, 1, *spatial, device=label_data.device)
+    value_shape = b, 1, 1, 1, 1
+
+    for label_val in _label_values_from(means_per_element):
+        means = _broadcast_values(
+            means_per_element,
+            label_val,
+            value_shape,
+            result,
         )
-        for index in range(label_data.shape[0])
-    ]
-    return torch.cat(outputs, dim=0)
+        stds = _broadcast_values(
+            stds_per_element,
+            label_val,
+            value_shape,
+            result,
+        )
+        if _is_all_zero(means) and _is_all_zero(stds):
+            continue
+        mask = (label_data[:, 0:1] == label_val).to(dtype=result.dtype)
+        tissue = torch.randn_like(result) * stds + means
+        result += tissue * mask
+
+    return result
+
+
+def _label_values_from(values_per_element: list[dict[int, float]]) -> list[int]:
+    """Get sorted label values represented by per-element dictionaries.
+
+    Args:
+        values_per_element: One value dictionary per batch element.
+
+    Returns:
+        Sorted union of labels in the dictionaries.
+    """
+    return sorted(set().union(*(values.keys() for values in values_per_element)))
+
+
+def _broadcast_values(
+    values_per_element: list[dict[int, float]],
+    label_val: int,
+    shape: tuple[int, int, int, int, int],
+    reference: Tensor,
+) -> Tensor:
+    """Convert per-element values for one label to a broadcastable tensor.
+
+    Args:
+        values_per_element: One value dictionary per batch element.
+        label_val: Label whose values are needed.
+        shape: Output tensor shape.
+        reference: Tensor defining device and dtype.
+
+    Returns:
+        Tensor shaped as `shape`, on the same device and dtype as `reference`.
+    """
+    values = [values.get(label_val, 0.0) for values in values_per_element]
+    return torch.as_tensor(
+        values,
+        device=reference.device,
+        dtype=reference.dtype,
+    ).reshape(shape)
+
+
+def _is_all_zero(values: Tensor) -> bool:
+    """Return whether all tensor entries are zero."""
+    return torch.count_nonzero(values).item() == 0
 
 
 def _generate_from_labels(

--- a/src/torchio/transforms/intensity/labels_to_image.py
+++ b/src/torchio/transforms/intensity/labels_to_image.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import torch
+from einops import rearrange
 from torch import Tensor
 
 from ...data.batch import SubjectsBatch
@@ -196,19 +197,16 @@ def _generate_per_element(
     b = label_data.shape[0]
     spatial = label_data.shape[2:]
     result = torch.zeros(b, 1, *spatial, device=label_data.device)
-    value_shape = b, 1, 1, 1, 1
 
     for label_val in _label_values_from(means_per_element):
         means = _broadcast_values(
             means_per_element,
             label_val,
-            value_shape,
             result,
         )
         stds = _broadcast_values(
             stds_per_element,
             label_val,
-            value_shape,
             result,
         )
         if _is_all_zero(means) and _is_all_zero(stds):
@@ -235,7 +233,6 @@ def _label_values_from(values_per_element: list[dict[int, float]]) -> list[int]:
 def _broadcast_values(
     values_per_element: list[dict[int, float]],
     label_val: int,
-    shape: tuple[int, int, int, int, int],
     reference: Tensor,
 ) -> Tensor:
     """Convert per-element values for one label to a broadcastable tensor.
@@ -243,18 +240,19 @@ def _broadcast_values(
     Args:
         values_per_element: One value dictionary per batch element.
         label_val: Label whose values are needed.
-        shape: Output tensor shape.
         reference: Tensor defining device and dtype.
 
     Returns:
-        Tensor shaped as `shape`, on the same device and dtype as `reference`.
+        Tensor of shape `(B, 1, 1, 1, 1)`, on the same device and dtype as
+            `reference`, broadcastable over `(B, 1, I, J, K)`.
     """
     values = [values.get(label_val, 0.0) for values in values_per_element]
-    return torch.as_tensor(
+    tensor = torch.as_tensor(
         values,
         device=reference.device,
         dtype=reference.dtype,
-    ).reshape(shape)
+    )
+    return rearrange(tensor, "b -> b 1 1 1 1")
 
 
 def _is_all_zero(values: Tensor) -> bool:

--- a/src/torchio/transforms/intensity/motion.py
+++ b/src/torchio/transforms/intensity/motion.py
@@ -48,7 +48,9 @@ class Motion(IntensityTransform):
         degrees: Rotation range in degrees.  A scalar $d$ means
             $\theta_i \sim \mathcal{U}(-d, d)$.  A 2-tuple $(a, b)$
             means $\theta_i \sim \mathcal{U}(a, b)$.
-        translation: Translation range in mm, same convention.
+        translation: Translation range in voxels, same convention as
+            *degrees*. The translation is applied in normalized grid
+            coordinates (a voxel-space approximation), not in millimeters.
         num_transforms: Number of inter-segment motion events.
             More transforms produce more distortion.
         **kwargs: See [`Transform`][torchio.Transform].

--- a/src/torchio/transforms/intensity/motion.py
+++ b/src/torchio/transforms/intensity/motion.py
@@ -2,17 +2,29 @@
 
 from __future__ import annotations
 
+from functools import partial
+from operator import itemgetter
 from typing import Any
 
-import numpy as np
 import torch
 import torch.nn.functional as functional
 from einops import rearrange
+from einops import repeat
 from torch import Tensor
 
 from ...data.batch import SubjectsBatch
 from ..parameter_range import to_range
 from ..transform import IntensityTransform
+
+RigidTransform = dict[str, tuple[float, float, float]]
+MotionTransforms = list[RigidTransform]
+PerElementMotionTransforms = list[MotionTransforms]
+MotionParameters = tuple[Tensor, Tensor]
+
+_IDENTITY_TRANSFORM: RigidTransform = {
+    "degrees": (0.0, 0.0, 0.0),
+    "translation": (0.0, 0.0, 0.0),
+}
 
 
 class Motion(IntensityTransform):
@@ -84,7 +96,7 @@ class Motion(IntensityTransform):
         self._tag_batched(params, batch, n, keep, ["transforms"])
         return params
 
-    def _sample_transforms(self) -> list[dict[str, tuple[float, float, float]]]:
+    def _sample_transforms(self) -> MotionTransforms:
         """Sample one list of rigid sub-transforms."""
         return [
             {
@@ -111,16 +123,10 @@ class Motion(IntensityTransform):
         per_instance = self._is_per_instance_params(params)
         for _name, img_batch in self._get_images(batch).items():
             if per_instance:
-                data = img_batch.data
-                outputs = []
-                for index in range(data.shape[0]):
-                    element_transforms = params["transforms"][index]
-                    slice_b = data[index : index + 1]
-                    if not element_transforms:
-                        outputs.append(slice_b)
-                        continue
-                    outputs.append(_apply_motion(slice_b, element_transforms))
-                img_batch.data = torch.cat(outputs, dim=0)
+                img_batch.data = _apply_motion_per_instance(
+                    img_batch.data,
+                    params["transforms"],
+                )
             else:
                 img_batch.data = _apply_motion(
                     img_batch.data,
@@ -131,7 +137,7 @@ class Motion(IntensityTransform):
 
 def _apply_motion(
     data: Tensor,
-    motion_transforms: list[dict[str, tuple[float, float, float]]],
+    motion_transforms: MotionTransforms,
 ) -> Tensor:
     """Apply motion corruption to a 5D tensor.
 
@@ -143,120 +149,405 @@ def _apply_motion(
     Returns:
         Motion-corrupted `(B, C, I, J, K)` tensor.
     """
+    if not motion_transforms:
+        return data
+    batch_size = data.shape[0]
+    segment_parameters = [
+        _shared_motion_parameters(transform, batch_size, data.device)
+        for transform in motion_transforms
+    ]
+    return _apply_motion_segments(data, segment_parameters)
+
+
+def _apply_motion_per_instance(
+    data: Tensor,
+    motion_transforms: PerElementMotionTransforms,
+) -> Tensor:
+    """Apply motion corruption with per-element rigid parameters.
+
+    Args:
+        data: `(B, C, I, J, K)` image tensor.
+        motion_transforms: One transform list per batch element. Empty
+            lists mark gated-out elements.
+
+    Returns:
+        Motion-corrupted `(B, C, I, J, K)` tensor, with inactive rows
+            restored exactly from the input.
+    """
+    _check_batch_size(data, motion_transforms)
+    active = _active_motion_mask(motion_transforms, data.device)
+    if not active.any().item():
+        return data
+    segment_parameters = [
+        _per_instance_motion_parameters(motion_transforms, segment_index, data.device)
+        for segment_index in range(_num_motion_transforms(motion_transforms))
+    ]
+    transformed = _apply_motion_segments(data, segment_parameters)
+    active = rearrange(active, "b -> b 1 1 1 1")
+    return torch.where(active, transformed, data)
+
+
+def _check_batch_size(
+    data: Tensor,
+    motion_transforms: PerElementMotionTransforms,
+) -> None:
+    """Validate that parameter lists match the batch size.
+
+    Args:
+        data: `(B, C, I, J, K)` image tensor.
+        motion_transforms: One transform list per batch element.
+
+    Raises:
+        ValueError: If the parameter count differs from the batch size.
+    """
+    if len(motion_transforms) == data.shape[0]:
+        return
+    msg = (
+        f"Expected {data.shape[0]} motion parameter lists, got {len(motion_transforms)}"
+    )
+    raise ValueError(msg)
+
+
+def _active_motion_mask(
+    motion_transforms: PerElementMotionTransforms,
+    device: torch.device,
+) -> Tensor:
+    """Return a boolean mask for elements with sampled motion.
+
+    Args:
+        motion_transforms: One transform list per batch element.
+        device: Device where the mask will be allocated.
+
+    Returns:
+        Boolean `(B,)` tensor.
+    """
+    return torch.as_tensor(
+        tuple(map(bool, motion_transforms)),
+        dtype=torch.bool,
+        device=device,
+    )
+
+
+def _num_motion_transforms(
+    motion_transforms: PerElementMotionTransforms,
+) -> int:
+    """Return the uniform number of transforms for active elements.
+
+    Args:
+        motion_transforms: One transform list per batch element.
+
+    Returns:
+        Number of rigid transforms per active element.
+
+    Raises:
+        ValueError: If active elements have inconsistent transform counts.
+    """
+    lengths = set(map(len, motion_transforms))
+    lengths.discard(0)
+    if len(lengths) <= 1:
+        return max(lengths, default=0)
+    msg = f"Expected uniform motion transform counts, got {sorted(lengths)}"
+    raise ValueError(msg)
+
+
+def _shared_motion_parameters(
+    motion_transform: RigidTransform,
+    batch_size: int,
+    device: torch.device,
+) -> MotionParameters:
+    """Convert a shared rigid transform into batched tensors.
+
+    Args:
+        motion_transform: Shared rigid transform parameters.
+        batch_size: Number of batch elements.
+        device: Device where tensors will be allocated.
+
+    Returns:
+        Batched degrees and translation tensors of shape `(B, 3)`.
+    """
+    degrees = _repeat_parameter(motion_transform["degrees"], batch_size, device)
+    translation = _repeat_parameter(
+        motion_transform["translation"],
+        batch_size,
+        device,
+    )
+    return degrees, translation
+
+
+def _per_instance_motion_parameters(
+    motion_transforms: PerElementMotionTransforms,
+    segment_index: int,
+    device: torch.device,
+) -> MotionParameters:
+    """Collect one segment's per-element parameters as tensors.
+
+    Args:
+        motion_transforms: One transform list per batch element.
+        segment_index: Segment transform index.
+        device: Device where tensors will be allocated.
+
+    Returns:
+        Batched degrees and translation tensors of shape `(B, 3)`.
+    """
+    get_segment_transform = partial(
+        _segment_transform_or_identity,
+        segment_index=segment_index,
+    )
+    segment_transforms = tuple(map(get_segment_transform, motion_transforms))
+    degrees = torch.as_tensor(
+        tuple(map(itemgetter("degrees"), segment_transforms)),
+        dtype=torch.float32,
+        device=device,
+    )
+    translation = torch.as_tensor(
+        tuple(map(itemgetter("translation"), segment_transforms)),
+        dtype=torch.float32,
+        device=device,
+    )
+    return degrees, translation
+
+
+def _segment_transform_or_identity(
+    transforms: MotionTransforms,
+    *,
+    segment_index: int,
+) -> RigidTransform:
+    """Return segment parameters or identity for inactive elements.
+
+    Args:
+        transforms: Rigid transform list for one batch element.
+        segment_index: Segment transform index.
+
+    Returns:
+        The segment's rigid transform or identity parameters.
+    """
+    if not transforms:
+        return _IDENTITY_TRANSFORM
+    return transforms[segment_index]
+
+
+def _repeat_parameter(
+    parameter: tuple[float, float, float],
+    batch_size: int,
+    device: torch.device,
+) -> Tensor:
+    """Repeat a shared 3-vector parameter across the batch.
+
+    Args:
+        parameter: Shared 3-vector parameter.
+        batch_size: Number of batch elements.
+        device: Device where the result will be allocated.
+
+    Returns:
+        `(B, 3)` float tensor.
+    """
+    tensor = torch.as_tensor(parameter, dtype=torch.float32, device=device)
+    return repeat(tensor, "component -> batch component", batch=batch_size)
+
+
+def _apply_motion_segments(
+    data: Tensor,
+    segment_parameters: list[MotionParameters],
+) -> Tensor:
+    """Apply k-space segment replacements for a whole batch.
+
+    Args:
+        data: `(B, C, I, J, K)` image tensor.
+        segment_parameters: Per-segment batched degrees and translations.
+
+    Returns:
+        Motion-corrupted `(B, C, I, J, K)` tensor.
+    """
     result = data.float()
-    num_transforms = len(motion_transforms)
-    num_segments = num_transforms + 1
+    num_segments = len(segment_parameters) + 1
+    spatial_shape = result.shape[-3:]
+    segment_size = spatial_shape[0] // num_segments
 
-    for b in range(result.shape[0]):
-        volume = result[b]  # (C, I, J, K)
-        spatial_shape = volume.shape[1:]
-        segment_size = spatial_shape[0] // num_segments
+    spectrum = torch.fft.fftn(result, dim=(-3, -2, -1))
+    for segment_index, (degrees, translation) in enumerate(
+        segment_parameters,
+        start=1,
+    ):
+        moved = _apply_rigid_transform(result, degrees, translation)
+        moved_spectrum = torch.fft.fftn(moved, dim=(-3, -2, -1))
+        start, end = _segment_bounds(
+            segment_index,
+            num_segments,
+            segment_size,
+            spatial_shape[0],
+        )
+        spectrum[:, :, start:end] = moved_spectrum[:, :, start:end]
 
-        # FFT all channels at once.
-        spectrum = torch.fft.fftn(volume, dim=(-3, -2, -1))
+    reconstructed = torch.fft.ifftn(spectrum, dim=(-3, -2, -1)).real
+    return reconstructed.to(data.dtype)
 
-        for seg_idx in range(1, num_segments):
-            transform = motion_transforms[seg_idx - 1]
-            moved = _apply_rigid_transform(
-                volume,
-                transform["degrees"],
-                transform["translation"],
-            )
-            moved_spectrum = torch.fft.fftn(moved, dim=(-3, -2, -1))
-            start = seg_idx * segment_size
-            end = (
-                (seg_idx + 1) * segment_size
-                if seg_idx < num_segments - 1
-                else spatial_shape[0]
-            )
-            spectrum[:, start:end] = moved_spectrum[:, start:end]
 
-        reconstructed = torch.fft.ifftn(spectrum, dim=(-3, -2, -1))
-        result[b] = reconstructed.real
+def _segment_bounds(
+    segment_index: int,
+    num_segments: int,
+    segment_size: int,
+    first_spatial_size: int,
+) -> tuple[int, int]:
+    """Return start and end indices for a k-space segment.
 
-    return result.to(data.dtype)
+    Args:
+        segment_index: One-based segment index.
+        num_segments: Total number of k-space segments.
+        segment_size: Size of every non-final segment.
+        first_spatial_size: Size of the first spatial axis.
+
+    Returns:
+        Start and end indices along the first spatial axis.
+    """
+    start = segment_index * segment_size
+    if segment_index == num_segments - 1:
+        return start, first_spatial_size
+    return start, (segment_index + 1) * segment_size
 
 
 def _apply_rigid_transform(
     tensor: Tensor,
-    degrees: tuple[float, float, float],
-    translation: tuple[float, float, float],
+    degrees: Tensor,
+    translation: Tensor,
 ) -> Tensor:
-    """Apply a rigid-body transform to a 4-D tensor using affine_grid.
+    """Apply per-element rigid-body transforms to a 5-D tensor.
 
-    All channels share the same grid so only one `affine_grid` call
-    is needed.
+    Each batch element gets its own affine grid, shared by all channels.
 
     Args:
-        tensor: `(C, I, J, K)` tensor.
-        degrees: Euler angles in degrees.
-        translation: Translation in voxels (approximation).
+        tensor: `(B, C, I, J, K)` tensor.
+        degrees: Euler angles in degrees, with shape `(B, 3)`.
+        translation: Translation in voxels, with shape `(B, 3)`.
 
     Returns:
-        Transformed `(C, I, J, K)` tensor.
+        Transformed `(B, C, I, J, K)` tensor.
     """
-    c = tensor.shape[0]
-    shape = tensor.shape[1:]  # (I, J, K)
-    radians = [np.radians(d) for d in degrees]
-    rx, ry, rz = radians
-
-    cos_x, sin_x = np.cos(rx), np.sin(rx)
-    cos_y, sin_y = np.cos(ry), np.sin(ry)
-    cos_z, sin_z = np.cos(rz), np.sin(rz)
-
-    r_x = torch.tensor(
-        [
-            [1, 0, 0],
-            [0, cos_x, -sin_x],
-            [0, sin_x, cos_x],
-        ],
-        dtype=torch.float32,
-    )
-
-    r_y = torch.tensor(
-        [
-            [cos_y, 0, sin_y],
-            [0, 1, 0],
-            [-sin_y, 0, cos_y],
-        ],
-        dtype=torch.float32,
-    )
-
-    r_z = torch.tensor(
-        [
-            [cos_z, -sin_z, 0],
-            [sin_z, cos_z, 0],
-            [0, 0, 1],
-        ],
-        dtype=torch.float32,
-    )
-
-    rotation = (r_z @ r_y @ r_x).to(tensor.device)
-
-    # Normalize translation to [-1, 1] grid coordinates.
-    shape_t = torch.tensor(shape, dtype=torch.float32)
-    t_normalized = torch.tensor(translation, dtype=torch.float32) / (shape_t / 2)
-    t_normalized = t_normalized.to(tensor.device)
-
-    # Build 3x4 affine matrix for affine_grid.
-    theta = torch.zeros(1, 3, 4, device=tensor.device)
-    theta[0, :3, :3] = rotation
-    theta[0, :3, 3] = t_normalized
-
-    # Single grid, reused for all channels.
+    batch_size, channels, *shape = tensor.shape
+    theta = _affine_matrices(degrees, translation, shape)
     grid = functional.affine_grid(
         theta,
-        [1, 1, shape[0], shape[1], shape[2]],
+        [batch_size, 1, shape[0], shape[1], shape[2]],
         align_corners=True,
     )
-    # Treat each channel as a batch element: (C, 1, I, J, K).
-    input_5d = rearrange(tensor, "c i j k -> c 1 i j k").float()
-    grid_c = grid.expand(c, -1, -1, -1, -1)
+    input_5d = rearrange(tensor, "b c i j k -> (b c) 1 i j k").float()
+    grid = repeat(grid, "b i j k xyz -> (b c) i j k xyz", c=channels)
     output = functional.grid_sample(
         input_5d,
-        grid_c,
+        grid,
         mode="bilinear",
         padding_mode="zeros",
         align_corners=True,
     )
-    return rearrange(output, "c 1 i j k -> c i j k")
+    return rearrange(output, "(b c) 1 i j k -> b c i j k", b=batch_size)
+
+
+def _affine_matrices(
+    degrees: Tensor,
+    translation: Tensor,
+    spatial_shape: list[int],
+) -> Tensor:
+    """Build batched affine matrices for `affine_grid`.
+
+    Args:
+        degrees: Euler angles in degrees, with shape `(B, 3)`.
+        translation: Translation in voxels, with shape `(B, 3)`.
+        spatial_shape: Spatial tensor shape `(I, J, K)`.
+
+    Returns:
+        Batched affine matrices with shape `(B, 3, 4)`.
+    """
+    theta = torch.zeros(
+        degrees.shape[0],
+        3,
+        4,
+        dtype=degrees.dtype,
+        device=degrees.device,
+    )
+    theta[:, :3, :3] = _rotation_matrices(degrees)
+    theta[:, :3, 3] = _normalized_translation(translation, spatial_shape)
+    return theta
+
+
+def _normalized_translation(
+    translation: Tensor,
+    spatial_shape: list[int],
+) -> Tensor:
+    """Normalize voxel translations to `affine_grid` coordinates.
+
+    Args:
+        translation: Translation in voxels, with shape `(B, 3)`.
+        spatial_shape: Spatial tensor shape `(I, J, K)`.
+
+    Returns:
+        Normalized translations with shape `(B, 3)`.
+    """
+    shape = torch.as_tensor(
+        spatial_shape,
+        dtype=translation.dtype,
+        device=translation.device,
+    )
+    return translation / (shape / 2)
+
+
+def _rotation_matrices(degrees: Tensor) -> Tensor:
+    """Build batched Euler rotation matrices.
+
+    Args:
+        degrees: Euler angles in degrees, with shape `(B, 3)`.
+
+    Returns:
+        Rotation matrices with shape `(B, 3, 3)`.
+    """
+    radians = torch.deg2rad(degrees)
+    rx, ry, rz = radians.unbind(dim=-1)
+    r_x = _axis_rotation_matrices(rx, axis=0)
+    r_y = _axis_rotation_matrices(ry, axis=1)
+    r_z = _axis_rotation_matrices(rz, axis=2)
+    return r_z @ r_y @ r_x
+
+
+def _axis_rotation_matrices(angles: Tensor, *, axis: int) -> Tensor:
+    """Build batched rotation matrices around one axis.
+
+    Args:
+        angles: Rotation angles in radians, with shape `(B,)`.
+        axis: Rotation axis, where 0, 1 and 2 are x, y and z.
+
+    Returns:
+        Rotation matrices with shape `(B, 3, 3)`.
+
+    Raises:
+        ValueError: If `axis` is not 0, 1 or 2.
+    """
+    cos = torch.cos(angles)
+    sin = torch.sin(angles)
+    matrices = torch.zeros(
+        angles.shape[0],
+        3,
+        3,
+        dtype=angles.dtype,
+        device=angles.device,
+    )
+    if axis == 0:
+        matrices[:, 0, 0] = 1
+        matrices[:, 1, 1] = cos
+        matrices[:, 1, 2] = -sin
+        matrices[:, 2, 1] = sin
+        matrices[:, 2, 2] = cos
+        return matrices
+    if axis == 1:
+        matrices[:, 0, 0] = cos
+        matrices[:, 0, 2] = sin
+        matrices[:, 1, 1] = 1
+        matrices[:, 2, 0] = -sin
+        matrices[:, 2, 2] = cos
+        return matrices
+    if axis == 2:
+        matrices[:, 0, 0] = cos
+        matrices[:, 0, 1] = -sin
+        matrices[:, 1, 0] = sin
+        matrices[:, 1, 1] = cos
+        matrices[:, 2, 2] = 1
+        return matrices
+    msg = f"Expected axis to be 0, 1 or 2, got {axis}"
+    raise ValueError(msg)

--- a/src/torchio/transforms/intensity/motion.py
+++ b/src/torchio/transforms/intensity/motion.py
@@ -364,7 +364,13 @@ def _apply_motion_segments(
     num_segments = len(segment_parameters) + 1
     spatial_shape = result.shape[-3:]
     segment_size = spatial_shape[0] // num_segments
-
+    if segment_size == 0:
+        msg = (
+            f"Cannot split {spatial_shape[0]} k-space slices into"
+            f" {num_segments} motion segments; reduce num_transforms or use a"
+            " larger image along the first spatial axis."
+        )
+        raise ValueError(msg)
     spectrum = torch.fft.fftn(result, dim=(-3, -2, -1))
     for segment_index, (degrees, translation) in enumerate(
         segment_parameters,

--- a/src/torchio/transforms/intensity/spike.py
+++ b/src/torchio/transforms/intensity/spike.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import torch
+from einops import rearrange
 from torch import Tensor
 
 from ...data.batch import SubjectsBatch
@@ -218,5 +219,5 @@ def _add_spikes_per_instance(
         torch.fft.ifftshift(spectrum, dim=(-3, -2, -1)),
         dim=(-3, -2, -1),
     ).real.to(data.dtype)
-    active = active.reshape(-1, 1, 1, 1, 1)
+    active = rearrange(active, "b -> b 1 1 1 1")
     return torch.where(active, transformed, data)

--- a/src/torchio/transforms/intensity/spike.py
+++ b/src/torchio/transforms/intensity/spike.py
@@ -44,6 +44,8 @@ class Spike(IntensityTransform):
         >>> transform = tio.Spike(num_spikes=3, intensity=2.0)
     """
 
+    __name__ = "Spike"
+
     def __init__(
         self,
         *,
@@ -73,8 +75,9 @@ class Spike(IntensityTransform):
         keep = self._keep_mask(batch, n)
         positions_list: list[list[list[float]]] = []
         intensity_list: list[float] = []
-        for index in range(n):
-            if keep is not None and not keep[index]:
+        keep_values = [True] * n if keep is None else keep.tolist()
+        for should_keep in keep_values:
+            if not should_keep:
                 positions_list.append([])
                 intensity_list.append(0.0)
                 continue
@@ -105,16 +108,11 @@ class Spike(IntensityTransform):
         per_instance = self._is_per_instance_params(params)
         for _name, img_batch in self._get_images(batch).items():
             if per_instance:
-                data = img_batch.data
-                outputs = [
-                    _add_spikes(
-                        data[index : index + 1],
-                        params["positions"][index],
-                        params["intensity"][index],
-                    )
-                    for index in range(data.shape[0])
-                ]
-                img_batch.data = torch.cat(outputs, dim=0)
+                img_batch.data = _add_spikes_per_instance(
+                    img_batch.data,
+                    params["positions"],
+                    params["intensity"],
+                )
             else:
                 img_batch.data = _add_spikes(
                     img_batch.data,
@@ -163,3 +161,64 @@ def _add_spikes(
         dim=(-3, -2, -1),
     ).real
     return result.to(data.dtype)
+
+
+def _add_spikes_per_instance(
+    data: Tensor,
+    positions: list[list[list[float]]],
+    intensities: list[float],
+) -> Tensor:
+    """Add independently sampled point spikes to a batched 5D tensor.
+
+    Args:
+        data: `(B, C, I, J, K)` image tensor.
+        positions: Per-element lists of `[pi, pj, pk]` positions in `[0, 1)`.
+        intensities: Per-element spike amplitude ratios.
+
+    Returns:
+        Corrupted `(B, C, I, J, K)` tensor, with inactive elements unchanged.
+    """
+    active = torch.as_tensor(
+        [
+            bool(batch_positions) and batch_intensity != 0
+            for batch_positions, batch_intensity in zip(
+                positions,
+                intensities,
+                strict=True,
+            )
+        ],
+        device=data.device,
+    )
+    if not active.any().item():
+        return data
+
+    result = data.float()
+    shape = result.shape[2:]  # (I, J, K)
+
+    spectrum = torch.fft.fftshift(
+        torch.fft.fftn(result, dim=(-3, -2, -1)),
+        dim=(-3, -2, -1),
+    )
+    peak = spectrum.abs().amax(dim=(-3, -2, -1), keepdim=True)
+
+    for batch_index, (batch_positions, batch_intensity) in enumerate(
+        zip(
+            positions,
+            intensities,
+            strict=True,
+        )
+    ):
+        if not batch_positions or batch_intensity == 0:
+            continue
+        for pos in batch_positions:
+            idx = [int(p * s) % s for p, s in zip(pos, shape, strict=True)]
+            spectrum[batch_index, :, idx[0], idx[1], idx[2]] += (
+                peak[batch_index, :, 0, 0, 0] * batch_intensity
+            )
+
+    transformed = torch.fft.ifftn(
+        torch.fft.ifftshift(spectrum, dim=(-3, -2, -1)),
+        dim=(-3, -2, -1),
+    ).real.to(data.dtype)
+    active = active.reshape(-1, 1, 1, 1, 1)
+    return torch.where(active, transformed, data)

--- a/src/torchio/transforms/intensity/spike.py
+++ b/src/torchio/transforms/intensity/spike.py
@@ -44,8 +44,6 @@ class Spike(IntensityTransform):
         >>> transform = tio.Spike(num_spikes=3, intensity=2.0)
     """
 
-    __name__ = "Spike"
-
     def __init__(
         self,
         *,

--- a/src/torchio/transforms/intensity/swap.py
+++ b/src/torchio/transforms/intensity/swap.py
@@ -13,6 +13,10 @@ from ...data.image import LabelMap
 from ..parameter_range import to_nonneg_range
 from ..transform import IntensityTransform
 
+Origin = tuple[int, int, int]
+SwapLocation = tuple[Origin, Origin]
+PatchIndices = tuple[Tensor, Tensor, Tensor, Tensor, Tensor]
+
 
 class Swap(IntensityTransform):
     r"""Randomly swap patches within an image.
@@ -112,18 +116,11 @@ class Swap(IntensityTransform):
         per_instance = self._is_per_instance_params(params)
         for _name, img_batch in self._get_images(batch).items():
             if per_instance:
-                data = img_batch.data
-                outputs = [
-                    _apply_swaps(
-                        data[index : index + 1],
-                        params["locations"][index],
-                        self.patch_size,
-                    )
-                    if params["locations"][index]
-                    else data[index : index + 1]
-                    for index in range(data.shape[0])
-                ]
-                img_batch.data = torch.cat(outputs, dim=0)
+                img_batch.data = _apply_swaps_per_instance(
+                    img_batch.data,
+                    params["locations"],
+                    self.patch_size,
+                )
             else:
                 img_batch.data = _apply_swaps(
                     img_batch.data,
@@ -137,7 +134,7 @@ def _sample_swap_locations(
     spatial_shape: tuple[int, ...],
     patch_size: tuple[int, int, int],
     num_iterations: int,
-) -> list[tuple[tuple[int, int, int], tuple[int, int, int]]]:
+) -> list[SwapLocation]:
     """Sample pairs of non-overlapping patch origins.
 
     Args:
@@ -148,7 +145,7 @@ def _sample_swap_locations(
     Returns:
         List of `(origin_a, origin_b)` tuples.
     """
-    locations: list[tuple[tuple[int, int, int], tuple[int, int, int]]] = []
+    locations: list[SwapLocation] = []
     max_ini = [s - p for s, p in zip(spatial_shape, patch_size, strict=True)]
     if any(m < 0 for m in max_ini):
         msg = (
@@ -171,7 +168,7 @@ def _sample_swap_locations(
 
 def _random_origin(
     max_ini: list[int],
-) -> tuple[int, int, int]:
+) -> Origin:
     """Sample a random patch origin."""
     coords = []
     for m in max_ini:
@@ -183,8 +180,8 @@ def _random_origin(
 
 
 def _patches_overlap(
-    a: tuple[int, int, int],
-    b: tuple[int, int, int],
+    a: Origin,
+    b: Origin,
     patch_size: tuple[int, int, int],
 ) -> bool:
     """Check whether two axis-aligned patches overlap."""
@@ -196,7 +193,7 @@ def _patches_overlap(
 
 def _apply_swaps(
     data: Tensor,
-    locations: list[tuple[tuple[int, int, int], tuple[int, int, int]]],
+    locations: list[SwapLocation],
     patch_size: tuple[int, int, int],
 ) -> Tensor:
     """Swap patch pairs in a 5D tensor.
@@ -219,3 +216,142 @@ def _apply_swaps(
         result[:, :, bi : bi + pi, bj : bj + pj, bk : bk + pk] = patch_a
 
     return result
+
+
+def _apply_swaps_per_instance(
+    data: Tensor,
+    locations: list[list[SwapLocation]],
+    patch_size: tuple[int, int, int],
+) -> Tensor:
+    """Swap per-element patch pairs in a 5D tensor.
+
+    Args:
+        data: `(B, C, I, J, K)` tensor.
+        locations: One list of `(origin_a, origin_b)` pairs per batch element.
+        patch_size: `(pi, pj, pk)` patch dimensions.
+
+    Returns:
+        Tensor with each element's patches swapped.
+    """
+    result = data.clone()
+    num_swaps = max(
+        (len(element_locations) for element_locations in locations), default=0
+    )
+    if num_swaps == 0:
+        return result
+
+    origins_a, origins_b = _get_batched_origins(
+        locations,
+        num_swaps,
+        data.device,
+    )
+    patch_indices = _make_patch_indices(data, patch_size)
+    for swap_index in range(num_swaps):
+        _swap_batched_patches(
+            result,
+            origins_a[:, swap_index],
+            origins_b[:, swap_index],
+            patch_indices,
+        )
+
+    return result
+
+
+def _get_batched_origins(
+    locations: list[list[SwapLocation]],
+    num_swaps: int,
+    device: torch.device,
+) -> tuple[Tensor, Tensor]:
+    """Build origin tensors for batched indexed swapping.
+
+    Args:
+        locations: One list of `(origin_a, origin_b)` pairs per batch element.
+        num_swaps: Number of sequential swap steps to encode.
+        device: Device on which the index tensors are created.
+
+    Returns:
+        Two tensors of shape `(B, num_swaps, 3)` for the first and second patch
+            origins.
+    """
+    batch_size = len(locations)
+    origins_a = torch.zeros(batch_size, num_swaps, 3, dtype=torch.long, device=device)
+    origins_b = torch.zeros_like(origins_a)
+    for batch_index, element_locations in enumerate(locations):
+        for swap_index, (origin_a, origin_b) in enumerate(element_locations):
+            origins_a[batch_index, swap_index] = torch.as_tensor(
+                origin_a,
+                dtype=torch.long,
+                device=device,
+            )
+            origins_b[batch_index, swap_index] = torch.as_tensor(
+                origin_b,
+                dtype=torch.long,
+                device=device,
+            )
+    return origins_a, origins_b
+
+
+def _make_patch_indices(
+    data: Tensor,
+    patch_size: tuple[int, int, int],
+) -> PatchIndices:
+    """Create shared batch, channel, and patch-offset index tensors.
+
+    Args:
+        data: `(B, C, I, J, K)` tensor.
+        patch_size: `(pi, pj, pk)` patch dimensions.
+
+    Returns:
+        Index tensors that broadcast to `(B, C, pi, pj, pk)`.
+    """
+    batch_size, channels = data.shape[:2]
+    pi, pj, pk = patch_size
+    device = data.device
+    batch_index = torch.arange(batch_size, device=device)[:, None, None, None, None]
+    channel_index = torch.arange(channels, device=device)[None, :, None, None, None]
+    i_offsets = torch.arange(pi, device=device)[None, None, :, None, None]
+    j_offsets = torch.arange(pj, device=device)[None, None, None, :, None]
+    k_offsets = torch.arange(pk, device=device)[None, None, None, None, :]
+    return batch_index, channel_index, i_offsets, j_offsets, k_offsets
+
+
+def _swap_batched_patches(
+    data: Tensor,
+    origins_a: Tensor,
+    origins_b: Tensor,
+    patch_indices: PatchIndices,
+) -> None:
+    """Swap one patch pair per batch element using batched indexing.
+
+    Args:
+        data: `(B, C, I, J, K)` tensor to update in place.
+        origins_a: Tensor of shape `(B, 3)` with first patch origins.
+        origins_b: Tensor of shape `(B, 3)` with second patch origins.
+        patch_indices: Broadcastable batch, channel, and offset indices.
+    """
+    indices_a = _get_patch_indices(origins_a, patch_indices)
+    indices_b = _get_patch_indices(origins_b, patch_indices)
+    patch_a = data[indices_a].clone()
+    patch_b = data[indices_b].clone()
+    data[indices_a] = patch_b
+    data[indices_b] = patch_a
+
+
+def _get_patch_indices(
+    origins: Tensor,
+    patch_indices: PatchIndices,
+) -> PatchIndices:
+    """Build full tensor indices for per-element patch origins.
+
+    Args:
+        origins: Tensor of shape `(B, 3)` with per-element patch origins.
+        patch_indices: Broadcastable batch, channel, and offset indices.
+
+    Returns:
+        Index tensors that select one patch per batch element.
+    """
+    batch_index, channel_index, i_offsets, j_offsets, k_offsets = patch_indices
+    i_index = origins[:, 0][:, None, None, None, None] + i_offsets
+    j_index = origins[:, 1][:, None, None, None, None] + j_offsets
+    k_index = origins[:, 2][:, None, None, None, None] + k_offsets
+    return batch_index, channel_index, i_index, j_index, k_index

--- a/src/torchio/transforms/intensity/swap.py
+++ b/src/torchio/transforms/intensity/swap.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Any
 
 import torch
+from einops import rearrange
 from torch import Tensor
 
 from ...data.batch import SubjectsBatch
@@ -307,11 +308,17 @@ def _make_patch_indices(
     batch_size, channels = data.shape[:2]
     pi, pj, pk = patch_size
     device = data.device
-    batch_index = torch.arange(batch_size, device=device)[:, None, None, None, None]
-    channel_index = torch.arange(channels, device=device)[None, :, None, None, None]
-    i_offsets = torch.arange(pi, device=device)[None, None, :, None, None]
-    j_offsets = torch.arange(pj, device=device)[None, None, None, :, None]
-    k_offsets = torch.arange(pk, device=device)[None, None, None, None, :]
+    batch_index = rearrange(
+        torch.arange(batch_size, device=device),
+        "b -> b 1 1 1 1",
+    )
+    channel_index = rearrange(
+        torch.arange(channels, device=device),
+        "c -> 1 c 1 1 1",
+    )
+    i_offsets = rearrange(torch.arange(pi, device=device), "i -> 1 1 i 1 1")
+    j_offsets = rearrange(torch.arange(pj, device=device), "j -> 1 1 1 j 1")
+    k_offsets = rearrange(torch.arange(pk, device=device), "k -> 1 1 1 1 k")
     return batch_index, channel_index, i_offsets, j_offsets, k_offsets
 
 
@@ -351,7 +358,7 @@ def _get_patch_indices(
         Index tensors that select one patch per batch element.
     """
     batch_index, channel_index, i_offsets, j_offsets, k_offsets = patch_indices
-    i_index = origins[:, 0][:, None, None, None, None] + i_offsets
-    j_index = origins[:, 1][:, None, None, None, None] + j_offsets
-    k_index = origins[:, 2][:, None, None, None, None] + k_offsets
+    i_index = rearrange(origins[:, 0], "b -> b 1 1 1 1") + i_offsets
+    j_index = rearrange(origins[:, 1], "b -> b 1 1 1 1") + j_offsets
+    k_index = rearrange(origins[:, 2], "b -> b 1 1 1 1") + k_offsets
     return batch_index, channel_index, i_index, j_index, k_index

--- a/src/torchio/transforms/spatial/anisotropy.py
+++ b/src/torchio/transforms/spatial/anisotropy.py
@@ -109,22 +109,12 @@ class Anisotropy(Transform):
             mode = "nearest" if is_label else self.image_interpolation
             if per_instance:
                 data = img_batch.data
-                outputs = []
-                for index in range(data.shape[0]):
-                    factor = params["factor"][index]
-                    slice_b = data[index : index + 1]
-                    if factor <= 1.0:
-                        outputs.append(slice_b)
-                        continue
-                    outputs.append(
-                        _simulate_anisotropy(
-                            slice_b,
-                            axis=params["axis"][index],
-                            factor=factor,
-                            mode=mode,
-                        )
-                    )
-                img_batch.data = torch.cat(outputs, dim=0)
+                img_batch.data = _simulate_anisotropy_per_instance(
+                    data,
+                    axes=params["axis"],
+                    factors=params["factor"],
+                    mode=mode,
+                )
             else:
                 factor = params["factor"]
                 if factor <= 1.0:
@@ -136,6 +126,219 @@ class Anisotropy(Transform):
                     mode=mode,
                 )
         return batch
+
+
+def _simulate_anisotropy_per_instance(
+    data: torch.Tensor,
+    *,
+    axes: list[int],
+    factors: list[float],
+    mode: str,
+) -> torch.Tensor:
+    """Downsample then upsample each batch element with its own parameters.
+
+    Args:
+        data: `(B, C, I, J, K)` tensor.
+        axes: Spatial axis per batch element.
+        factors: Downsampling factor per batch element.
+        mode: Interpolation mode for upsampling (`"nearest"` or
+            `"linear"`).
+
+    Returns:
+        Degraded `(B, C, I, J, K)` tensor with original shape.
+    """
+    axes_tensor = torch.as_tensor(axes, dtype=torch.long, device=data.device)
+    factors_tensor = torch.as_tensor(
+        factors,
+        dtype=torch.float64,
+        device=data.device,
+    )
+    active = factors_tensor > 1.0
+    if not bool(active.any()):
+        return data.to(data.dtype)
+
+    output = data.clone()
+    for axis in range(3):
+        axis_mask = active & (axes_tensor == axis)
+        if not bool(axis_mask.any()):
+            continue
+        output[axis_mask] = _simulate_anisotropy_fixed_axis(
+            data[axis_mask],
+            factors=factors_tensor[axis_mask],
+            axis=axis,
+            mode=mode,
+        )
+    return output.to(data.dtype)
+
+
+def _simulate_anisotropy_fixed_axis(
+    data: torch.Tensor,
+    *,
+    factors: torch.Tensor,
+    axis: int,
+    mode: str,
+) -> torch.Tensor:
+    """Downsample then upsample one axis with per-element factors.
+
+    Args:
+        data: `(B, C, I, J, K)` tensor whose elements share `axis`.
+        factors: Downsampling factors for the batch elements.
+        axis: Spatial axis (0, 1, or 2) to degrade.
+        mode: Interpolation mode for upsampling (`"nearest"` or
+            `"linear"`).
+
+    Returns:
+        Degraded `(B, C, I, J, K)` tensor with original shape.
+    """
+    length = data.shape[axis + 2]
+    down_sizes = _downsample_sizes(length, factors)
+    if mode == "nearest":
+        indices = _nearest_source_indices(length, down_sizes, data.device)
+        return _gather_axis(data.float(), indices, axis).to(data.dtype)
+    lower, upper, weights = _linear_source_indices(length, down_sizes, data.device)
+    lower_values = _gather_axis(data.float(), lower, axis)
+    upper_values = _gather_axis(data.float(), upper, axis)
+    weights = _broadcast_axis_weights(weights, axis)
+    degraded = lower_values * (1.0 - weights) + upper_values * weights
+    return degraded.to(data.dtype)
+
+
+def _downsample_sizes(length: int, factors: torch.Tensor) -> torch.Tensor:
+    """Return PyTorch-compatible nearest-downsampled sizes.
+
+    Args:
+        length: Original length along the degraded axis.
+        factors: Per-element downsampling factors.
+
+    Returns:
+        Downsampled sizes matching `round(length / factor)`.
+    """
+    sizes = torch.round(length / factors).clamp_min(1)
+    return sizes.to(torch.long)
+
+
+def _nearest_source_indices(
+    length: int,
+    down_sizes: torch.Tensor,
+    device: torch.device,
+) -> torch.Tensor:
+    """Return original-axis indices for nearest downsample and upsample.
+
+    Args:
+        length: Original length along the degraded axis.
+        down_sizes: Downsampled sizes per batch element.
+        device: Device where the indices should be created.
+
+    Returns:
+        A `(B, length)` tensor of source indices.
+    """
+    positions = torch.arange(length, dtype=torch.long, device=device)
+    lowres_indices = torch.div(
+        positions * down_sizes[:, None],
+        length,
+        rounding_mode="floor",
+    )
+    return _downsample_source_indices(length, down_sizes, lowres_indices)
+
+
+def _linear_source_indices(
+    length: int,
+    down_sizes: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return source indices and weights for trilinear upsampling.
+
+    Args:
+        length: Original length along the degraded axis.
+        down_sizes: Downsampled sizes per batch element.
+        device: Device where the indices should be created.
+
+    Returns:
+        Lower source indices, upper source indices and upper weights,
+            each shaped `(B, length)`.
+    """
+    positions = torch.arange(length, dtype=torch.float32, device=device)
+    if length == 1:
+        lowres_positions = torch.zeros(
+            len(down_sizes),
+            1,
+            dtype=torch.float32,
+            device=device,
+        )
+    else:
+        scale = (down_sizes.to(torch.float32) - 1.0) / (length - 1)
+        lowres_positions = positions * scale[:, None]
+    lower_lowres = lowres_positions.floor().to(torch.long)
+    upper_lowres = torch.minimum(lower_lowres + 1, down_sizes[:, None] - 1)
+    weights = lowres_positions - lower_lowres.to(torch.float32)
+    lower = _downsample_source_indices(length, down_sizes, lower_lowres)
+    upper = _downsample_source_indices(length, down_sizes, upper_lowres)
+    return lower, upper, weights
+
+
+def _downsample_source_indices(
+    length: int,
+    down_sizes: torch.Tensor,
+    lowres_indices: torch.Tensor,
+) -> torch.Tensor:
+    """Map low-resolution indices to nearest-downsampled source indices.
+
+    Args:
+        length: Original length along the degraded axis.
+        down_sizes: Downsampled sizes per batch element.
+        lowres_indices: Low-resolution indices.
+
+    Returns:
+        Original source indices.
+    """
+    source = torch.div(
+        lowres_indices * length,
+        down_sizes[:, None],
+        rounding_mode="floor",
+    )
+    return source.clamp(max=length - 1)
+
+
+def _gather_axis(
+    data: torch.Tensor,
+    source_indices: torch.Tensor,
+    axis: int,
+) -> torch.Tensor:
+    """Gather `data` along one spatial axis with per-element indices.
+
+    Args:
+        data: `(B, C, I, J, K)` tensor.
+        source_indices: `(B, N)` indices for the selected spatial axis.
+        axis: Spatial axis (0, 1, or 2) to gather.
+
+    Returns:
+        Gathered `(B, C, I, J, K)` tensor.
+    """
+    if axis == 0:
+        indices = source_indices[:, None, :, None, None]
+    elif axis == 1:
+        indices = source_indices[:, None, None, :, None]
+    else:
+        indices = source_indices[:, None, None, None, :]
+    indices = indices.expand_as(data)
+    return torch.gather(data, dim=axis + 2, index=indices)
+
+
+def _broadcast_axis_weights(weights: torch.Tensor, axis: int) -> torch.Tensor:
+    """Broadcast interpolation weights over channels and untouched axes.
+
+    Args:
+        weights: `(B, N)` interpolation weights.
+        axis: Spatial axis (0, 1, or 2) corresponding to `N`.
+
+    Returns:
+        Weights broadcast-compatible with `(B, C, I, J, K)`.
+    """
+    if axis == 0:
+        return weights[:, None, :, None, None]
+    if axis == 1:
+        return weights[:, None, None, :, None]
+    return weights[:, None, None, None, :]
 
 
 def _simulate_anisotropy(

--- a/src/torchio/transforms/spatial/anisotropy.py
+++ b/src/torchio/transforms/spatial/anisotropy.py
@@ -157,6 +157,11 @@ def _simulate_anisotropy_per_instance(
     if not bool(active.any()):
         return data.to(data.dtype)
 
+    active_axes = axes_tensor[active]
+    if bool(((active_axes < 0) | (active_axes > 2)).any()):
+        msg = f"Anisotropy axis must be in {{0, 1, 2}}, got {sorted(set(axes))}"
+        raise ValueError(msg)
+
     output = data.clone()
     for axis in range(3):
         axis_mask = active & (axes_tensor == axis)

--- a/src/torchio/transforms/spatial/anisotropy.py
+++ b/src/torchio/transforms/spatial/anisotropy.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import torch
 import torch.nn.functional as functional
+from einops import rearrange
 
 from ...data.batch import SubjectsBatch
 from ...data.image import LabelMap
@@ -239,7 +240,7 @@ def _nearest_source_indices(
     """
     positions = torch.arange(length, dtype=torch.long, device=device)
     lowres_indices = torch.div(
-        positions * down_sizes[:, None],
+        positions * rearrange(down_sizes, "b -> b 1"),
         length,
         rounding_mode="floor",
     )
@@ -272,9 +273,12 @@ def _linear_source_indices(
         )
     else:
         scale = (down_sizes.to(torch.float32) - 1.0) / (length - 1)
-        lowres_positions = positions * scale[:, None]
+        lowres_positions = positions * rearrange(scale, "b -> b 1")
     lower_lowres = lowres_positions.floor().to(torch.long)
-    upper_lowres = torch.minimum(lower_lowres + 1, down_sizes[:, None] - 1)
+    upper_lowres = torch.minimum(
+        lower_lowres + 1,
+        rearrange(down_sizes, "b -> b 1") - 1,
+    )
     weights = lowres_positions - lower_lowres.to(torch.float32)
     lower = _downsample_source_indices(length, down_sizes, lower_lowres)
     upper = _downsample_source_indices(length, down_sizes, upper_lowres)
@@ -298,7 +302,7 @@ def _downsample_source_indices(
     """
     source = torch.div(
         lowres_indices * length,
-        down_sizes[:, None],
+        rearrange(down_sizes, "b -> b 1"),
         rounding_mode="floor",
     )
     return source.clamp(max=length - 1)
@@ -320,11 +324,11 @@ def _gather_axis(
         Gathered `(B, C, I, J, K)` tensor.
     """
     if axis == 0:
-        indices = source_indices[:, None, :, None, None]
+        indices = rearrange(source_indices, "b n -> b 1 n 1 1")
     elif axis == 1:
-        indices = source_indices[:, None, None, :, None]
+        indices = rearrange(source_indices, "b n -> b 1 1 n 1")
     else:
-        indices = source_indices[:, None, None, None, :]
+        indices = rearrange(source_indices, "b n -> b 1 1 1 n")
     indices = indices.expand_as(data)
     return torch.gather(data, dim=axis + 2, index=indices)
 
@@ -340,10 +344,10 @@ def _broadcast_axis_weights(weights: torch.Tensor, axis: int) -> torch.Tensor:
         Weights broadcast-compatible with `(B, C, I, J, K)`.
     """
     if axis == 0:
-        return weights[:, None, :, None, None]
+        return rearrange(weights, "b n -> b 1 n 1 1")
     if axis == 1:
-        return weights[:, None, None, :, None]
-    return weights[:, None, None, None, :]
+        return rearrange(weights, "b n -> b 1 1 n 1")
+    return rearrange(weights, "b n -> b 1 1 1 n")
 
 
 def _simulate_anisotropy(

--- a/src/torchio/transforms/spatial/flip.py
+++ b/src/torchio/transforms/spatial/flip.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import torch
+from einops import rearrange
 
 from ...data.batch import ImagesBatch
 from ...data.batch import SubjectsBatch
@@ -219,12 +220,22 @@ def _flip_per_element(
     Returns:
         The flipped `(B, C, I, J, K)` tensor.
     """
-    outputs = []
-    for index in range(data.shape[0]):
-        dims = [a - 3 for a in axes_per_element[index]]
-        slice_b = data[index : index + 1]
-        outputs.append(torch.flip(slice_b, dims) if dims else slice_b)
-    return torch.cat(outputs, dim=0)
+    batch_size = data.shape[0]
+    result = data
+    # Flip the whole batch along each spatial axis once, then select per
+    # element with a boolean mask. Flips along distinct axes commute, so
+    # composing them sequentially matches flipping an element's axes at once.
+    for spatial_axis in range(3):
+        flip_flags = torch.tensor(
+            [spatial_axis in axes_per_element[index] for index in range(batch_size)],
+            device=data.device,
+        )
+        if not bool(flip_flags.any()):
+            continue
+        flipped = torch.flip(result, [spatial_axis - 3])
+        mask = rearrange(flip_flags, "b -> b 1 1 1 1")
+        result = torch.where(mask, flipped, result)
+    return result
 
 
 class _FlipInverse(SpatialTransform):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,60 @@
+"""Shared pytest fixtures for the test suite."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+import torch
+
+from torchio.data.batch import SubjectsBatch
+from torchio.data.batch import _slice_params
+
+
+@pytest.fixture
+def assert_vectorized() -> Callable[..., None]:
+    """Return an assertion that a per-instance transform is vectorized faithfully.
+
+    The returned helper applies *transform* to a batch (per-instance) and then,
+    for every element, re-applies the same per-element parameters to that
+    element alone. The two must match, which proves the vectorized whole-batch
+    computation is equivalent to processing each element independently (no
+    cross-element contamination or broadcasting mistakes).
+
+    This is only valid for transforms whose `apply_transform` is deterministic
+    given the recorded parameters (the randomness lives in `make_params`).
+    Transforms that sample inside `apply_transform` (e.g. Noise, LabelsToImage)
+    need a different check.
+    """
+
+    def _assert(
+        transform: Any,
+        batch: SubjectsBatch,
+        *,
+        rtol: float = 1e-5,
+        atol: float = 1e-6,
+    ) -> None:
+        original = copy.deepcopy(batch)
+        result = transform(batch)
+        params = result.applied_transforms[-1].params
+        assert "_batched_keys" in params, "per-instance path was not active"
+        batched_keys = params["_batched_keys"]
+        image_names = list(transform._get_images(result).keys())
+        result_images = transform._get_images(result)
+        original_subjects = original.unbatch()
+        for index in range(original.batch_size):
+            single = SubjectsBatch.from_subjects([original_subjects[index]])
+            element_params = _slice_params(params, index, batched_keys)
+            single = transform.apply_transform(single, element_params)
+            single_images = transform._get_images(single)
+            for name in image_names:
+                torch.testing.assert_close(
+                    result_images[name].data[index : index + 1],
+                    single_images[name].data,
+                    rtol=rtol,
+                    atol=atol,
+                )
+
+    return _assert

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,20 +41,35 @@ def assert_vectorized() -> Callable[..., None]:
         params = result.applied_transforms[-1].params
         assert "_batched_keys" in params, "per-instance path was not active"
         batched_keys = params["_batched_keys"]
+        keep = params.get("_keep")
         image_names = list(transform._get_images(result).keys())
         result_images = transform._get_images(result)
         original_subjects = original.unbatch()
         for index in range(original.batch_size):
             single = SubjectsBatch.from_subjects([original_subjects[index]])
+            single_input = {
+                name: image.data.clone()
+                for name, image in transform._get_images(single).items()
+            }
             element_params = _slice_params(params, index, batched_keys)
             single = transform.apply_transform(single, element_params)
             single_images = transform._get_images(single)
+            gated_out = keep is not None and not keep[index]
             for name in image_names:
+                result_row = result_images[name].data[index : index + 1]
                 torch.testing.assert_close(
-                    result_images[name].data[index : index + 1],
+                    result_row,
                     single_images[name].data,
                     rtol=rtol,
                     atol=atol,
                 )
+                if gated_out:
+                    # A gated-out element must be a bit-for-bit no-op.
+                    torch.testing.assert_close(
+                        result_row,
+                        single_input[name],
+                        rtol=0,
+                        atol=0,
+                    )
 
     return _assert

--- a/tests/test_anisotropy.py
+++ b/tests/test_anisotropy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 import torch
 
 import torchio as tio
@@ -77,3 +78,20 @@ class TestAnisotropyPerInstance:
         subject = tio.Subject(t1=tio.ScalarImage(torch.rand(1, 12, 12, 12)))
         result = tio.Anisotropy(downsampling=(2.0, 5.0))(subject)
         assert "_batched_keys" not in result.applied_transforms[-1].params
+
+
+class TestAnisotropyAxisValidation:
+    def test_out_of_range_axis_raises(self) -> None:
+        # An active per-element axis outside {0, 1, 2} must raise, matching the
+        # scalar path, rather than silently becoming a no-op.
+        from torchio.transforms.spatial.anisotropy import (
+            _simulate_anisotropy_per_instance,
+        )
+
+        with pytest.raises(ValueError, match="axis must be in"):
+            _simulate_anisotropy_per_instance(
+                torch.rand(2, 1, 8, 8, 8),
+                axes=[0, 3],
+                factors=[2.0, 2.0],
+                mode="linear",
+            )

--- a/tests/test_labels_to_image.py
+++ b/tests/test_labels_to_image.py
@@ -95,3 +95,40 @@ class TestLabelsToImagePerInstance:
         subject = _make_subject()
         result = tio.LabelsToImage(label_key="seg", default_mean=(0.2, 0.9))(subject)
         assert isinstance(result.applied_transforms[-1].params["means"], dict)
+
+
+class TestLabelsToImagePerElementVectorized:
+    def test_each_element_uses_its_own_label_stats(self) -> None:
+        # The vectorized per-element generation must give each batch element
+        # its own per-label mean (no cross-element contamination), even though
+        # the random draw order differs from the old per-element loop.
+        size = 16
+        label = torch.zeros(1, size, size, size)
+        label[0, : size // 2] = 1
+        label[0, size // 2 :] = 2
+        batch = tio.SubjectsBatch.from_subjects(
+            [tio.Subject(seg=tio.LabelMap(label.clone())) for _ in range(3)]
+        )
+        transform = tio.LabelsToImage(
+            label_key="seg",
+            image_key="img",
+            default_mean=(0.0, 100.0),
+            default_std=(0.0, 0.05),
+        )
+        torch.manual_seed(1)
+        result = transform(batch)
+        params = result.applied_transforms[-1].params
+        assert "_batched_keys" in params
+        image = result.img.data
+        for index in range(batch.batch_size):
+            region_one = image[index, 0, : size // 2]
+            region_two = image[index, 0, size // 2 :]
+            assert region_one.mean().item() == pytest.approx(
+                params["means"][index][1], abs=0.5
+            )
+            assert region_two.mean().item() == pytest.approx(
+                params["means"][index][2], abs=0.5
+            )
+        # Independent per-element sampling: means vary across the batch.
+        label_one_means = {round(params["means"][i][1], 3) for i in range(3)}
+        assert len(label_one_means) > 1

--- a/tests/test_motion.py
+++ b/tests/test_motion.py
@@ -82,3 +82,13 @@ class TestMotionPerInstance:
         subject = tio.Subject(t1=tio.ScalarImage(torch.rand(1, 12, 12, 12)))
         result = tio.Motion(degrees=15, translation=10)(subject)
         assert "_batched_keys" not in result.applied_transforms[-1].params
+
+
+class TestMotionDegenerateSegments:
+    def test_too_many_transforms_for_first_axis_raises(self) -> None:
+        # num_transforms + 1 segments cannot exceed the first spatial axis
+        # size; the transform must raise a clear error rather than silently
+        # replacing the whole spectrum.
+        subject = tio.Subject(t1=tio.ScalarImage(torch.rand(1, 2, 8, 8)))
+        with pytest.raises(ValueError, match="motion segments"):
+            tio.Motion(degrees=5, translation=5, num_transforms=4)(subject)

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -1,0 +1,68 @@
+"""Equivalence gate: per-instance batch transforms must be vectorized.
+
+Each transform here has an `apply_transform` that is deterministic given the
+recorded parameters (the randomness lives in `make_params`). The
+`assert_vectorized` fixture checks that applying the transform to a batch
+produces, for every element, the same result as applying the element's own
+parameters to that element alone. A correct vectorized implementation passes;
+any cross-element contamination or broadcasting mistake fails.
+
+Transforms that sample inside `apply_transform` (Noise, LabelsToImage) are
+excluded here and covered by their own tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+import torchio as tio
+
+
+def _batch(
+    batch_size: int = 4, dtype: torch.dtype = torch.float32
+) -> tio.SubjectsBatch:
+    data = torch.rand(1, 12, 12, 12, dtype=dtype)
+    subjects = [
+        tio.Subject(t1=tio.ScalarImage(data.clone() + index))
+        for index in range(batch_size)
+    ]
+    return tio.SubjectsBatch.from_subjects(subjects)
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        tio.Ghosting(num_ghosts=(2, 5), intensity=(0.5, 1.0)),
+        tio.Spike(num_spikes=(1, 3), intensity=(0.3, 0.8)),
+        tio.Blur(std=(0.5, 2.0)),
+        tio.BiasField(std=(0.3, 0.8)),
+        tio.Flip(axes=(0, 1, 2), flip_probability=0.5),
+        tio.Motion(degrees=10.0, translation=10.0, num_transforms=2),
+        tio.Swap(patch_size=3, num_iterations=5),
+        tio.Anisotropy(downsampling=(1.5, 4.0)),
+    ],
+)
+def test_vectorized_matches_per_element(transform, assert_vectorized) -> None:
+    torch.manual_seed(0)
+    assert_vectorized(transform, _batch())
+
+
+@pytest.mark.parametrize(
+    "transform",
+    [
+        tio.Ghosting(num_ghosts=4, intensity=1.0, p=0.5),
+        tio.Spike(num_spikes=2, intensity=1.0, p=0.5),
+        tio.Blur(std=1.5, p=0.5),
+        tio.BiasField(std=0.5, p=0.5),
+        tio.Flip(axes=(0, 1, 2), flip_probability=1.0, p=0.5),
+        tio.Motion(degrees=10.0, translation=10.0, num_transforms=2, p=0.5),
+        tio.Swap(patch_size=3, num_iterations=5, p=0.5),
+    ],
+)
+def test_vectorized_matches_per_element_with_gating(
+    transform,
+    assert_vectorized,
+) -> None:
+    torch.manual_seed(0)
+    assert_vectorized(transform, _batch(batch_size=6))

--- a/tests/test_vectorization.py
+++ b/tests/test_vectorization.py
@@ -66,3 +66,16 @@ def test_vectorized_matches_per_element_with_gating(
 ) -> None:
     torch.manual_seed(0)
     assert_vectorized(transform, _batch(batch_size=6))
+
+
+def test_anisotropy_tie_rounding_matches_scalar(assert_vectorized) -> None:
+    # An odd spatial length with factor 2.0 makes length/factor land on a .5
+    # tie (e.g. 9/2 = 4.5). The per-instance path uses torch.round and the
+    # scalar path uses Python round; both must agree (round-half-to-even), so
+    # the vectorized per-element result must match the scalar application.
+    torch.manual_seed(0)
+    data = torch.rand(1, 9, 9, 9)
+    batch = tio.SubjectsBatch.from_subjects(
+        [tio.Subject(t1=tio.ScalarImage(data.clone() + index)) for index in range(4)]
+    )
+    assert_vectorized(tio.Anisotropy(downsampling=2.0), batch)


### PR DESCRIPTION
[Generated by a coding agent]

---

Stacked on #1473 (base: `per-instance-augmentation`).

## Vectorize all per-instance batch transforms

Per the principle that **batch transforms should always be vectorized**, this PR replaces the per-element `for index in range(B): … torch.cat` loops in the per-instance transforms with whole-batch tensor operations using broadcast per-element parameters.

### Transforms vectorized
- **Flip**: per-axis whole-batch flips selected with `torch.where`.
- **Ghosting / Spike**: a single batched `fftn`/`ifftn` with a per-element k-space mask (Ghosting) / per-element peak scatter (Spike).
- **BiasField**: stack per-seed coarse noise, then one batched `interpolate` → `exp` → multiply.
- **Blur**: grouped `conv3d` with per-element separable kernels (`groups = B*C`).
- **Motion**: batched FFTs + grid-resampled rigid transforms, mixing k-space segments across the batch.
- **LabelsToImage**: per-label batched generation with broadcast per-element stats.
- **Anisotropy**: group by spatial axis, batch the resample per group.
- **Swap**: batched indexed patch swaps.

### Correctness gate
`tests/conftest.py::assert_vectorized` (used by `tests/test_vectorization.py`) asserts that, for transforms whose `apply_transform` is deterministic given the recorded params, the batched result for each element equals applying that element's own parameters alone — proving the whole-batch computation is faithful per-element with no cross-element contamination. It also asserts gated-out elements are **bit-for-bit** no-ops. LabelsToImage (which samples inside `apply`) has a dedicated per-element correctness test.

Every transform preserves input dtype and leaves per-element gated-out elements (`_keep == False`) exactly unchanged. Motion was verified to match the previous implementation to float32 precision.

Full test suite green (1379 passed), `mise run quality` (ruff + ty) and `prek` (incl. Xenon complexity) green. A GPT 5.5 review was addressed (gate hardened to bit-exact gated rows; LabelsToImage per-element test added).
