### PR TITLE
Support v1 tensor= keyword for backward compatibility (#1247)

### DIFF
--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -184,8 +184,9 @@ class Image(Invertible):
         **kwargs: Any,
     ):
         # Backward compatibility: v1 used tensor= keyword, v2 uses positional source
-        if 'tensor' in kwargs and source is None:
+        if "tensor" in kwargs and source is None:
             import warnings
+
             warnings.warn(
                 "Passing 'tensor=' as a keyword argument is deprecated. "
                 "Use the positional argument instead: "
@@ -193,7 +194,7 @@ class Image(Invertible):
                 DeprecationWarning,
                 stacklevel=2,
             )
-            source = kwargs.pop('tensor')
+            source = kwargs.pop("tensor")
 
         # Common state shared by all source types.
         self._reader = reader or default_reader

--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -183,6 +183,18 @@ class Image(Invertible):
         bounding_boxes: dict[str, BoundingBoxes] | None = None,
         **kwargs: Any,
     ):
+        # Backward compatibility: v1 used tensor= keyword, v2 uses positional source
+        if 'tensor' in kwargs and source is None:
+            import warnings
+            warnings.warn(
+                "Passing 'tensor=' as a keyword argument is deprecated. "
+                "Use the positional argument instead: "
+                f"{type(self).__name__}(your_tensor)",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            source = kwargs.pop('tensor')
+
         # Common state shared by all source types.
         self._reader = reader or default_reader
         self._reader_kwargs: dict[str, Any] = dict(reader_kwargs or {})

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -173,7 +173,7 @@ class TestBackwardCompatibleTensorKeyword:
             mask = LabelMap(tensor=torch.randint(0, 2, (1, 10, 10, 10)))
         subject = Subject(image=image, mask=mask)
         result = Flip()(subject)
-        assert result['image'].data.shape == (1, 10, 10, 10)
+        assert result["image"].data.shape == (1, 10, 10, 10)
 
 
 class TestImageProperties:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -133,6 +133,49 @@ class TestImageCreationFromTensor:
         assert image.is_loaded
 
 
+class TestBackwardCompatibleTensorKeyword:
+    """Tests for v1 backward compatibility: tensor= keyword argument."""
+
+    def test_tensor_keyword_loads_data(self):
+        tensor = torch.randn(1, 10, 10, 10)
+        with pytest.warns(DeprecationWarning, match="tensor="):
+            image = ScalarImage(tensor=tensor)
+        assert image.is_loaded
+        assert torch.equal(image.data, tensor)
+
+    def test_tensor_keyword_label_map(self):
+        tensor = torch.randint(0, 5, (1, 10, 10, 10))
+        with pytest.warns(DeprecationWarning, match="tensor="):
+            image = LabelMap(tensor=tensor)
+        assert image.is_loaded
+        assert torch.equal(image.data, tensor)
+
+    def test_tensor_keyword_numpy(self):
+        array = np.random.randn(1, 10, 10, 10).astype(np.float32)
+        with pytest.warns(DeprecationWarning, match="tensor="):
+            image = ScalarImage(tensor=array)
+        assert image.is_loaded
+
+    def test_tensor_keyword_with_affine(self):
+        tensor = torch.randn(1, 10, 10, 10)
+        affine = np.diag([2.0, 2.0, 2.0, 1.0])
+        with pytest.warns(DeprecationWarning, match="tensor="):
+            image = ScalarImage(tensor=tensor, affine=affine)
+        assert image.is_loaded
+        np.testing.assert_array_equal(image.affine, affine)
+
+    def test_tensor_keyword_in_subject_transform(self):
+        """Regression test for issue #1247."""
+        from torchio import Subject, Flip
+
+        with pytest.warns(DeprecationWarning, match="tensor="):
+            image = ScalarImage(tensor=torch.randn(1, 10, 10, 10))
+            mask = LabelMap(tensor=torch.randint(0, 2, (1, 10, 10, 10)))
+        subject = Subject(image=image, mask=mask)
+        result = Flip()(subject)
+        assert result['image'].data.shape == (1, 10, 10, 10)
+
+
 class TestImageProperties:
     @pytest.fixture
     def image(self) -> ScalarImage:


### PR DESCRIPTION
## Summary

Fixes #1247 — `ScalarImage(tensor=...)` and `LabelMap(tensor=...)` silently fail in v2 because the `tensor=` keyword is swallowed by `**kwargs` and stored as metadata instead of being used as image data.

### Root Cause

The v2 API changed the constructor from `Image(tensor=your_tensor)` to `Image(your_tensor)` (positional `source` argument). However, the old `tensor=` keyword was still accepted without error — it just got silently stored in `self._metadata` via `**kwargs`. This caused:

1. `self._data` remained `None` after construction
2. Accessing `.data` triggered `load()` which failed with `RuntimeError: Cannot load: no path or backend set`
3. Any transform applied to a Subject containing such images would crash

### Fix

Added backward-compatibility handling in `Image.__init__` that:
- Detects when `tensor=` is passed as a keyword argument
- Uses it as the `source` parameter
- Emits a `DeprecationWarning` guiding users to the new positional API

### Verification

**5 new tests added** covering:
- `tensor=` keyword loads data correctly (ScalarImage)
- `tensor=` keyword works with LabelMap
- `tensor=` keyword works with numpy arrays
- `tensor=` keyword with custom affine
- Full Subject + transform workflow (regression test for #1247)

```
tests/test_image.py::TestBackwardCompatibleTensorKeyword::test_tensor_keyword_loads_data PASSED
tests/test_image.py::TestBackwardCompatibleTensorKeyword::test_tensor_keyword_label_map PASSED
tests/test_image.py::TestBackwardCompatibleTensorKeyword::test_tensor_keyword_numpy PASSED
tests/test_image.py::TestBackwardCompatibleTensorKeyword::test_tensor_keyword_with_affine PASSED
tests/test_image.py::TestBackwardCompatibleTensorKeyword::test_tensor_keyword_in_subject_transform PASSED
```

**Full test suite:** 190 passed, 2 pre-existing failures (missing optional `nifti-zarr` dependency).

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-v2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
