### PR TITLE
Preserve inverse transform image scope

### DIFF
--- a/src/torchio/data/invertible.py
+++ b/src/torchio/data/invertible.py
@@ -42,6 +42,7 @@ class Invertible:
 
         return get_inverse_transform(
             self.applied_transforms,
+            data=self,
             warn=warn,
             ignore_intensity=ignore_intensity,
         )

--- a/src/torchio/data/invertible.py
+++ b/src/torchio/data/invertible.py
@@ -42,7 +42,6 @@ class Invertible:
 
         return get_inverse_transform(
             self.applied_transforms,
-            data=self,
             warn=warn,
             ignore_intensity=ignore_intensity,
         )

--- a/src/torchio/transforms/inverse.py
+++ b/src/torchio/transforms/inverse.py
@@ -15,6 +15,7 @@ from .transform import Transform
 def get_inverse_transform(
     history: list[AppliedTransform],
     *,
+    data: Any | None = None,
     warn: bool = True,
     ignore_intensity: bool = False,
 ) -> Compose:
@@ -26,6 +27,7 @@ def get_inverse_transform(
 
     Args:
         history: List of `AppliedTransform` records.
+        data: Data that will receive the inverse transforms.
         warn: Issue a warning for non-invertible transforms.
         ignore_intensity: Skip all intensity transforms.
 
@@ -33,6 +35,7 @@ def get_inverse_transform(
         A `Compose` of inverse transforms.
     """
     steps: list[Transform] = []
+    current_image_names = _get_image_names(data)
     for trace in reversed(history):
         cls = _TRANSFORM_REGISTRY.get(trace.name)
         if cls is None:
@@ -52,10 +55,41 @@ def get_inverse_transform(
                     stacklevel=2,
                 )
             continue
-        steps.append(instance.inverse(trace.params))
+        inverse = instance.inverse(trace.params)
+        if not _restrict_inverse_to_trace_images(
+            inverse,
+            trace,
+            current_image_names,
+        ):
+            continue
+        steps.append(inverse)
     # copy=True (the default) so applying the inverse does not mutate the
     # caller's data in place, matching every other transform.
     return Compose(steps)
+
+
+def _restrict_inverse_to_trace_images(
+    inverse: Transform,
+    trace: AppliedTransform,
+    current_image_names: set[str] | None,
+) -> bool:
+    if trace.image_names is None or current_image_names is None:
+        return True
+    matching_names = [name for name in trace.image_names if name in current_image_names]
+    if not matching_names:
+        return False
+    inverse.include = matching_names
+    inverse.exclude = None
+    return True
+
+
+def _get_image_names(data: Any | None) -> set[str] | None:
+    if data is None:
+        return None
+    images = getattr(data, "images", None)
+    if images is None:
+        return None
+    return set(images)
 
 
 def apply_inverse_transform(
@@ -88,6 +122,7 @@ def apply_inverse_transform(
         )
     inverse = get_inverse_transform(
         data.applied_transforms,
+        data=data,
         warn=warn,
         ignore_intensity=ignore_intensity,
     )

--- a/src/torchio/transforms/inverse.py
+++ b/src/torchio/transforms/inverse.py
@@ -15,7 +15,6 @@ from .transform import Transform
 def get_inverse_transform(
     history: list[AppliedTransform],
     *,
-    data: Any | None = None,
     warn: bool = True,
     ignore_intensity: bool = False,
 ) -> Compose:
@@ -27,7 +26,6 @@ def get_inverse_transform(
 
     Args:
         history: List of `AppliedTransform` records.
-        data: Data that will receive the inverse transforms.
         warn: Issue a warning for non-invertible transforms.
         ignore_intensity: Skip all intensity transforms.
 
@@ -35,7 +33,6 @@ def get_inverse_transform(
         A `Compose` of inverse transforms.
     """
     steps: list[Transform] = []
-    current_image_names = _get_image_names(data)
     for trace in reversed(history):
         cls = _TRANSFORM_REGISTRY.get(trace.name)
         if cls is None:
@@ -56,40 +53,12 @@ def get_inverse_transform(
                 )
             continue
         inverse = instance.inverse(trace.params)
-        if not _restrict_inverse_to_trace_images(
-            inverse,
-            trace,
-            current_image_names,
-        ):
-            continue
+        inverse.include = trace.include
+        inverse.exclude = trace.exclude
         steps.append(inverse)
     # copy=True (the default) so applying the inverse does not mutate the
     # caller's data in place, matching every other transform.
     return Compose(steps)
-
-
-def _restrict_inverse_to_trace_images(
-    inverse: Transform,
-    trace: AppliedTransform,
-    current_image_names: set[str] | None,
-) -> bool:
-    if trace.image_names is None or current_image_names is None:
-        return True
-    matching_names = [name for name in trace.image_names if name in current_image_names]
-    if not matching_names:
-        return False
-    inverse.include = matching_names
-    inverse.exclude = None
-    return True
-
-
-def _get_image_names(data: Any | None) -> set[str] | None:
-    if data is None:
-        return None
-    images = getattr(data, "images", None)
-    if images is None:
-        return None
-    return set(images)
 
 
 def apply_inverse_transform(
@@ -122,7 +91,6 @@ def apply_inverse_transform(
         )
     inverse = get_inverse_transform(
         data.applied_transforms,
-        data=data,
         warn=warn,
         ignore_intensity=ignore_intensity,
     )

--- a/src/torchio/transforms/spatial/crop_or_pad.py
+++ b/src/torchio/transforms/spatial/crop_or_pad.py
@@ -512,6 +512,7 @@ class CropOrPad(SpatialTransform):
     ) -> None:
         """Apply lazy pad/crop and record history."""
         images = _get_images(subject, self.include, self.exclude)
+        image_names = list(images)
 
         if padding is not None:
             for name, image in images.items():
@@ -529,21 +530,28 @@ class CropOrPad(SpatialTransform):
                         "padding_mode": self.padding_mode,
                         "fill": self.fill,
                     },
+                    image_names=image_names,
                 ),
             )
 
         if cropping is not None:
             images = _get_images(subject, self.include, self.exclude)
+            image_names = list(images)
             for name, image in images.items():
                 subject._images[name] = _crop_image_lazy(image, cropping)
             subject.applied_transforms.append(
-                AppliedTransform(name="Crop", params={"cropping": cropping}),
+                AppliedTransform(
+                    name="Crop",
+                    params={"cropping": cropping},
+                    image_names=image_names,
+                ),
             )
 
         subject.applied_transforms.append(
             AppliedTransform(
                 name="CropOrPad",
                 params={"padding": padding, "cropping": cropping},
+                image_names=image_names,
             ),
         )
 

--- a/src/torchio/transforms/spatial/crop_or_pad.py
+++ b/src/torchio/transforms/spatial/crop_or_pad.py
@@ -512,7 +512,8 @@ class CropOrPad(SpatialTransform):
     ) -> None:
         """Apply lazy pad/crop and record history."""
         images = _get_images(subject, self.include, self.exclude)
-        image_names = list(images)
+        include = list(self.include) if self.include is not None else None
+        exclude = list(self.exclude) if self.exclude is not None else None
 
         if padding is not None:
             for name, image in images.items():
@@ -530,20 +531,21 @@ class CropOrPad(SpatialTransform):
                         "padding_mode": self.padding_mode,
                         "fill": self.fill,
                     },
-                    image_names=image_names,
+                    include=include,
+                    exclude=exclude,
                 ),
             )
 
         if cropping is not None:
             images = _get_images(subject, self.include, self.exclude)
-            image_names = list(images)
             for name, image in images.items():
                 subject._images[name] = _crop_image_lazy(image, cropping)
             subject.applied_transforms.append(
                 AppliedTransform(
                     name="Crop",
                     params={"cropping": cropping},
-                    image_names=image_names,
+                    include=include,
+                    exclude=exclude,
                 ),
             )
 
@@ -551,7 +553,8 @@ class CropOrPad(SpatialTransform):
             AppliedTransform(
                 name="CropOrPad",
                 params={"padding": padding, "cropping": cropping},
-                image_names=image_names,
+                include=include,
+                exclude=exclude,
             ),
         )
 

--- a/src/torchio/transforms/spatial/crop_or_pad.py
+++ b/src/torchio/transforms/spatial/crop_or_pad.py
@@ -512,8 +512,8 @@ class CropOrPad(SpatialTransform):
     ) -> None:
         """Apply lazy pad/crop and record history."""
         images = _get_images(subject, self.include, self.exclude)
-        include = list(self.include) if self.include is not None else None
-        exclude = list(self.exclude) if self.exclude is not None else None
+        include = None if self.include is None else list(self.include)
+        exclude = None if self.exclude is None else list(self.exclude)
 
         if padding is not None:
             for name, image in images.items():

--- a/src/torchio/transforms/transform.py
+++ b/src/torchio/transforms/transform.py
@@ -33,12 +33,14 @@ class AppliedTransform:
     Attributes:
         name: Class name of the transform.
         params: Sampled parameters (JSON-serializable).
-        image_names: Names of images affected by the transform.
+        include: Original include scope of the applied transform.
+        exclude: Original exclude scope of the applied transform.
     """
 
     name: str
     params: dict[str, Any] = field(default_factory=dict)
-    image_names: list[str] | None = None
+    include: list[str] | None = None
+    exclude: list[str] | None = None
 
 
 #: Registry mapping transform class names to classes, for inverse lookup.
@@ -58,6 +60,10 @@ def _all_elements_gated_out(params: dict[str, Any]) -> bool:
     """
     keep = params.get("_keep")
     return keep is not None and not any(keep)
+
+
+def _copy_optional_list(value: list[str] | None) -> list[str] | None:
+    return None if value is None else list(value)
 
 
 class Transform(nn.Module):
@@ -221,7 +227,6 @@ class Transform(nn.Module):
         if not self._per_instance_p_active(batch) and torch.rand(1).item() >= self.p:
             return unwrap(batch)
         params = self.make_params(batch)
-        image_names = list(self._get_images(batch))
         batch = self.apply_transform(batch, params)
         # Record history on the batch, unless every element was gated out by
         # per-element probability: that is an exact no-op, and recording it
@@ -231,7 +236,8 @@ class Transform(nn.Module):
             trace = AppliedTransform(
                 name=type(self).__name__,
                 params=params,
-                image_names=image_names,
+                include=_copy_optional_list(self.include),
+                exclude=_copy_optional_list(self.exclude),
             )
             if not hasattr(batch, "applied_transforms"):
                 batch.applied_transforms = []

--- a/src/torchio/transforms/transform.py
+++ b/src/torchio/transforms/transform.py
@@ -33,10 +33,12 @@ class AppliedTransform:
     Attributes:
         name: Class name of the transform.
         params: Sampled parameters (JSON-serializable).
+        image_names: Names of images affected by the transform.
     """
 
     name: str
     params: dict[str, Any] = field(default_factory=dict)
+    image_names: list[str] | None = None
 
 
 #: Registry mapping transform class names to classes, for inverse lookup.
@@ -219,13 +221,18 @@ class Transform(nn.Module):
         if not self._per_instance_p_active(batch) and torch.rand(1).item() >= self.p:
             return unwrap(batch)
         params = self.make_params(batch)
+        image_names = list(self._get_images(batch))
         batch = self.apply_transform(batch, params)
         # Record history on the batch, unless every element was gated out by
         # per-element probability: that is an exact no-op, and recording it
         # would let history replay (e.g. an invertible spatial transform)
         # trigger an unnecessary identity resample.
         if not _all_elements_gated_out(params):
-            trace = AppliedTransform(name=type(self).__name__, params=params)
+            trace = AppliedTransform(
+                name=type(self).__name__,
+                params=params,
+                image_names=image_names,
+            )
             if not hasattr(batch, "applied_transforms"):
                 batch.applied_transforms = []
             batch.applied_transforms.append(trace)

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -168,6 +168,20 @@ class TestFlip:
         restored = flipped.apply_inverse_transform()
         torch.testing.assert_close(restored.t1.data, tensor)
 
+    def test_inverse_respects_include_scope(self) -> None:
+        a = torch.arange(8.0).reshape(1, 2, 2, 2)
+        b = torch.arange(100.0, 108.0).reshape(1, 2, 2, 2)
+        subject = tio.Subject(
+            a=tio.ScalarImage(a.clone()),
+            b=tio.ScalarImage(b.clone()),
+        )
+
+        transformed = tio.Flip(axes=(0,), include=["a"])(subject)
+        restored = transformed.apply_inverse_transform()
+
+        torch.testing.assert_close(restored.a.data, a)
+        torch.testing.assert_close(restored.b.data, b)
+
     def test_compose_inverse(self) -> None:
         """Compose inverse via Subject.apply_inverse_transform."""
         tensor = torch.rand(1, 4, 5, 6)
@@ -184,17 +198,17 @@ class TestFlip:
         torch.testing.assert_close(restored.t1.data, tensor)
 
     def test_inverse_on_image_via_subject(self) -> None:
-        """Inverse works by copying history to a new subject."""
+        """Inverse works when copied history image names match."""
         tensor = torch.rand(1, 4, 5, 6)
         subject = tio.Subject(t1=tio.ScalarImage(tensor.clone()))
         flipped = tio.Flip(axes=0)(subject)
-        # Create a prediction subject and copy history
+        # Create a new subject and copy history
         pred_subject = tio.Subject(
-            pred=tio.ScalarImage(flipped.t1.data.clone()),
+            t1=tio.ScalarImage(flipped.t1.data.clone()),
         )
         pred_subject.applied_transforms = flipped.applied_transforms
         restored = pred_subject.apply_inverse_transform()
-        torch.testing.assert_close(restored.pred.data, tensor)
+        torch.testing.assert_close(restored.t1.data, tensor)
 
     def test_inverse_skips_non_invertible(self) -> None:
         """Non-invertible transforms are skipped with a warning."""

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -198,17 +198,17 @@ class TestFlip:
         torch.testing.assert_close(restored.t1.data, tensor)
 
     def test_inverse_on_image_via_subject(self) -> None:
-        """Inverse works when copied history image names match."""
+        """Inverse works by copying history to a renamed prediction subject."""
         tensor = torch.rand(1, 4, 5, 6)
         subject = tio.Subject(t1=tio.ScalarImage(tensor.clone()))
         flipped = tio.Flip(axes=0)(subject)
-        # Create a new subject and copy history
+        # Create a prediction subject and copy history
         pred_subject = tio.Subject(
-            t1=tio.ScalarImage(flipped.t1.data.clone()),
+            pred=tio.ScalarImage(flipped.t1.data.clone()),
         )
         pred_subject.applied_transforms = flipped.applied_transforms
         restored = pred_subject.apply_inverse_transform()
-        torch.testing.assert_close(restored.t1.data, tensor)
+        torch.testing.assert_close(restored.pred.data, tensor)
 
     def test_inverse_skips_non_invertible(self) -> None:
         """Non-invertible transforms are skipped with a warning."""

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -43,6 +43,34 @@ class TestGamma:
             atol=1e-4,
         )
 
+    def test_inverse_respects_include_scope(self) -> None:
+        a = torch.arange(8.0).reshape(1, 2, 2, 2)
+        b = torch.arange(100.0, 108.0).reshape(1, 2, 2, 2)
+        subject = tio.Subject(
+            a=tio.ScalarImage(a.clone()),
+            b=tio.ScalarImage(b.clone()),
+        )
+
+        transformed = tio.Gamma(log_gamma=0.5, include=["a"])(subject)
+        restored = transformed.apply_inverse_transform()
+
+        torch.testing.assert_close(restored.a.data, a)
+        torch.testing.assert_close(restored.b.data, b)
+
+    def test_inverse_respects_exclude_scope(self) -> None:
+        a = torch.arange(8.0).reshape(1, 2, 2, 2)
+        b = torch.arange(100.0, 108.0).reshape(1, 2, 2, 2)
+        subject = tio.Subject(
+            a=tio.ScalarImage(a.clone()),
+            b=tio.ScalarImage(b.clone()),
+        )
+
+        transformed = tio.Gamma(log_gamma=0.5, exclude=["b"])(subject)
+        restored = transformed.apply_inverse_transform()
+
+        torch.testing.assert_close(restored.a.data, a)
+        torch.testing.assert_close(restored.b.data, b)
+
     def test_leaves_labels_unchanged(self) -> None:
         subject = _make_subject()
         original_seg = subject.seg.data.clone()

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -111,3 +111,18 @@ class TestApplyInverseTransform:
         original = subject.t1.data.clone()
         restored = subject.apply_inverse_transform()
         torch.testing.assert_close(restored.t1.data, original)
+
+    def test_missing_trace_image_skips_inverse(self) -> None:
+        a = torch.arange(8.0).reshape(1, 2, 2, 2)
+        b = torch.arange(100.0, 108.0).reshape(1, 2, 2, 2)
+        subject = tio.Subject(
+            a=tio.ScalarImage(a.clone()),
+            b=tio.ScalarImage(b.clone()),
+        )
+
+        transformed = tio.Gamma(log_gamma=0.5, include=["a"])(subject)
+        current = tio.Subject(b=transformed.b)
+        current.applied_transforms = transformed.applied_transforms
+        restored = current.apply_inverse_transform()
+
+        torch.testing.assert_close(restored.b.data, b)

--- a/tests/test_inverse.py
+++ b/tests/test_inverse.py
@@ -112,7 +112,7 @@ class TestApplyInverseTransform:
         restored = subject.apply_inverse_transform()
         torch.testing.assert_close(restored.t1.data, original)
 
-    def test_missing_trace_image_skips_inverse(self) -> None:
+    def test_missing_included_image_is_noop(self) -> None:
         a = torch.arange(8.0).reshape(1, 2, 2, 2)
         b = torch.arange(100.0, 108.0).reshape(1, 2, 2, 2)
         subject = tio.Subject(

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -126,3 +126,18 @@ class TestCropPadInvertibility:
         assert transformed.t1.shape == (1, 22, 22, 22)
         restored = transformed.apply_inverse_transform()
         assert restored.t1.shape == (1, 20, 20, 20)
+
+    def test_crop_or_pad_inverse_respects_include_scope(self) -> None:
+        a = torch.ones(1, 4, 4, 4)
+        b = torch.ones(1, 4, 4, 4) * 2
+        subject = tio.Subject(
+            a=tio.ScalarImage(a.clone()),
+            b=tio.ScalarImage(b.clone()),
+        )
+
+        transformed = tio.CropOrPad(6, include=["a"])(subject)
+        restored = transformed.apply_inverse_transform()
+
+        assert restored.a.shape == (1, 4, 4, 4)
+        torch.testing.assert_close(restored.a.data, a)
+        torch.testing.assert_close(restored.b.data, b)


### PR DESCRIPTION
## Summary
- record the image names affected by each applied transform
- restrict rebuilt inverse transforms to those names when they exist on the current data
- add Gamma include/exclude and Flip include regression coverage

Fixes #1480.

## Tests
- uv run --group test pytest tests/test_gamma.py tests/test_flip.py -q -k 'inverse_respects_include_scope or inverse_respects_exclude_scope'
- uv run --group test pytest tests/test_gamma.py tests/test_flip.py tests/test_inverse.py tests/test_transforms_base.py -q
- uv run --group test pytest tests/test_bias_field.py tests/test_normalize.py tests/test_standardize.py tests/test_remap_labels.py tests/test_one_hot.py tests/test_sequential_labels.py tests/test_transpose.py tests/test_crop.py tests/test_pad.py -q
- uv run --group test pytest -m 'not slow' -q
- uv run --group quality ruff check
- uv run --group quality ruff format --check
- uv run python -m compileall -q src tests
- uvx --with tox-uv tox -e lint,types,format

AI assistance was used under my direction.
