### PR TITLE
Make subject batching lossless

### DIFF
--- a/docs/get-started/migration.md
+++ b/docs/get-started/migration.md
@@ -358,9 +358,8 @@ for the capability contract and stochastic-realisation caveats.
 ### Migrate inherently per-subject logic
 
 Prefer vectorized operations on 5D tensors or metadata lists. If logic
-must call a subject-oriented external API, the current low-level escape
-hatch is to unbatch, process every subject without changing its schema,
-restack, and adopt the prior history:
+must call a subject-oriented external API, use
+`SubjectsBatch.map_subjects()`:
 
 ```python
 from typing import Any
@@ -382,13 +381,12 @@ class StripIdentifier(tio.Transform):
         params: dict[str, Any],
     ) -> tio.SubjectsBatch:
         """Process metadata one subject at a time."""
-        subjects = batch.unbatch()
-        for subject in subjects:
-            identifier = subject.metadata["identifier"]
-            subject.metadata["identifier"] = identifier.strip()
-        rebuilt = tio.SubjectsBatch.from_subjects(subjects)
-        rebuilt.adopt_history(batch, subjects)
-        return rebuilt
+        return batch.map_subjects(self._strip_identifier)
+
+    @staticmethod
+    def _strip_identifier(subject: tio.Subject) -> tio.Subject:
+        subject.metadata["identifier"] = subject.identifier.strip()
+        return subject
 
 
 subject = tio.Subject(
@@ -399,10 +397,9 @@ result = StripIdentifier()(subject)
 assert result.identifier == "sub-01"
 ```
 
-This pattern is more expensive than vectorized code and requires every
-resulting subject to retain a compatible image and metadata schema. A
-supported mapping utility is planned, but it is not part of the current
-API.
+This pattern is more expensive than vectorized code. Uniform schema
+changes are supported, but all callback results must remain compatible
+enough to be re-stacked.
 
 ## New features
 

--- a/src/torchio/data/batch.py
+++ b/src/torchio/data/batch.py
@@ -577,7 +577,7 @@ def _make_image_template(image: Image) -> Image:
         dtype=image.data.dtype,
         device=image.data.device,
     )
-    template = image.new_like(data=data, affine=image.affine)
+    template = image.new_like(data=data)
     template._metadata = _copy.deepcopy(image.metadata)
     template.applied_transforms = list(image.applied_transforms)
     return template

--- a/src/torchio/data/batch.py
+++ b/src/torchio/data/batch.py
@@ -57,7 +57,7 @@ class ImagesBatch(Invertible):
         if len(affines) != data.shape[0]:
             msg = f"Expected {data.shape[0]} affines, got {len(affines)}"
             raise ValueError(msg)
-        if not issubclass(image_class, Image):
+        if not isinstance(image_class, type) or not issubclass(image_class, Image):
             msg = f"Expected an Image subclass, got {image_class!r}"
             raise TypeError(msg)
         if image_templates is not None and len(image_templates) != data.shape[0]:

--- a/src/torchio/data/batch.py
+++ b/src/torchio/data/batch.py
@@ -277,42 +277,14 @@ class SubjectsBatch(Invertible):
         Args:
             subjects: `Subject` instances to stack.
         """
-        from .subject import Subject
-
-        if not subjects:
-            msg = "Cannot create batch from empty list"
-            raise ValueError(msg)
-        for index, subject in enumerate(subjects):
-            if not isinstance(subject, Subject):
-                msg = f"Expected Subject at index {index}, got {type(subject).__name__}"
-                raise TypeError(msg)
-
-        first: Subject = subjects[0]
+        first = _validate_subject_inputs(subjects)
         _validate_subject_schemas(subjects)
 
-        images: dict[str, ImagesBatch] = {}
-        for name in first.images:
-            img_list = [sub.images[name] for sub in subjects]
-            images[name] = ImagesBatch.from_images(img_list)
-
-        points = {
-            name: [_copy.deepcopy(subject.points[name]) for subject in subjects]
-            for name in first.points
-        }
-        bounding_boxes = {
-            name: [_copy.deepcopy(subject.bounding_boxes[name]) for subject in subjects]
-            for name in first.bounding_boxes
-        }
-        metadata = {
-            key: [_copy.deepcopy(subject.metadata[key]) for subject in subjects]
-            for key in first.metadata
-        }
-
         batch = cls(
-            images,
-            points=points,
-            bounding_boxes=bounding_boxes,
-            metadata=metadata,
+            _stack_subject_images(subjects, first),
+            points=_collect_subject_points(subjects, first),
+            bounding_boxes=_collect_subject_boxes(subjects, first),
+            metadata=_collect_subject_metadata(subjects, first),
         )
         _assign_histories(
             batch,
@@ -564,6 +536,64 @@ class SubjectsBatch(Invertible):
 
 # Alias for radiology users (see Subject/Study note in subject.py).
 StudiesBatch = SubjectsBatch
+
+
+def _validate_subject_inputs(subjects: Sequence[Any]) -> Subject:
+    """Validate subject input types and return the first subject."""
+    from .subject import Subject
+
+    if not subjects:
+        msg = "Cannot create batch from empty list"
+        raise ValueError(msg)
+    for index, subject in enumerate(subjects):
+        if not isinstance(subject, Subject):
+            msg = f"Expected Subject at index {index}, got {type(subject).__name__}"
+            raise TypeError(msg)
+    return subjects[0]
+
+
+def _stack_subject_images(
+    subjects: Sequence[Subject],
+    first: Subject,
+) -> dict[str, ImagesBatch]:
+    """Stack each named image across subjects."""
+    return {
+        name: ImagesBatch.from_images([subject.images[name] for subject in subjects])
+        for name in first.images
+    }
+
+
+def _collect_subject_points(
+    subjects: Sequence[Subject],
+    first: Subject,
+) -> dict[str, list[Points]]:
+    """Collect subject-level points without sharing mutable objects."""
+    return {
+        name: [_copy.deepcopy(subject.points[name]) for subject in subjects]
+        for name in first.points
+    }
+
+
+def _collect_subject_boxes(
+    subjects: Sequence[Subject],
+    first: Subject,
+) -> dict[str, list[BoundingBoxes]]:
+    """Collect subject-level boxes without sharing mutable objects."""
+    return {
+        name: [_copy.deepcopy(subject.bounding_boxes[name]) for subject in subjects]
+        for name in first.bounding_boxes
+    }
+
+
+def _collect_subject_metadata(
+    subjects: Sequence[Subject],
+    first: Subject,
+) -> dict[str, list[Any]]:
+    """Collect subject metadata without sharing mutable objects."""
+    return {
+        key: [_copy.deepcopy(subject.metadata[key]) for subject in subjects]
+        for key in first.metadata
+    }
 
 
 def _make_image_template(image: Image) -> Image:

--- a/src/torchio/data/batch.py
+++ b/src/torchio/data/batch.py
@@ -38,6 +38,11 @@ class ImagesBatch(Invertible):
         data: 5D tensor with shape `(B, C, I, J, K)`.
         affines: List of affine matrices, one per sample.
         image_class: The `Image` subclass to use when unbatching.
+        image_templates: Optional per-element image prototypes used to
+            preserve subclasses, metadata, annotations, and other image
+            payload when unbatching. The sequence length must match the
+            batch size. If `None`, images are reconstructed from
+            `image_class`.
     """
 
     def __init__(
@@ -133,7 +138,15 @@ class ImagesBatch(Invertible):
         return self._data.device
 
     def to(self, *args: Any, **kwargs: Any) -> Self:
-        """Move batch data to a device and/or cast dtype."""
+        """Move batch data to a device and/or cast dtype.
+
+        Args:
+            *args: Positional arguments forwarded to `torch.Tensor.to`.
+            **kwargs: Keyword arguments forwarded to `torch.Tensor.to`.
+
+        Returns:
+            `self` (modified in-place).
+        """
         self._data = self._data.to(*args, **kwargs)
         for affine in self._affines:
             affine.to(*args, **kwargs)
@@ -143,7 +156,14 @@ class ImagesBatch(Invertible):
         return self
 
     def __getitem__(self, index: int) -> Image:
-        """Get a single image from the batch by index."""
+        """Get a single image from the batch by index.
+
+        Args:
+            index: Batch element index.
+
+        Returns:
+            The reconstructed image for the selected element.
+        """
         if self._image_templates is None:
             image = self._image_class(
                 self._data[index],
@@ -177,7 +197,11 @@ class ImagesBatch(Invertible):
         )
 
     def set_per_element_history(self, histories: list[list[Any]]) -> None:
-        """Freeze a distinct transform history for each batch element."""
+        """Freeze a distinct transform history for each batch element.
+
+        Args:
+            histories: One transform-history list per batch element.
+        """
         if len(histories) != self.batch_size:
             msg = (
                 f"Expected {self.batch_size} per-element histories,"
@@ -193,7 +217,11 @@ class ImagesBatch(Invertible):
         self._per_element_history = None
 
     def get_inverse_transform(self, **kwargs: Any) -> Any:
-        """Build a transform that inverts the recorded history."""
+        """Build a transform that inverts the recorded history.
+
+        Args:
+            **kwargs: Forwarded to `Invertible.get_inverse_transform`.
+        """
         if self._per_element_history is not None:
             msg = (
                 "This image batch has per-element transform histories, so a"
@@ -204,7 +232,14 @@ class ImagesBatch(Invertible):
         return super().get_inverse_transform(**kwargs)
 
     def apply_inverse_transform(self, **kwargs: Any) -> ImagesBatch:
-        """Apply the inverse of the recorded history."""
+        """Apply the inverse of the recorded history.
+
+        Args:
+            **kwargs: Forwarded to `get_inverse_transform`.
+
+        Returns:
+            A batch with the transforms undone.
+        """
         if self._per_element_history is not None:
             inverted = [image.apply_inverse_transform(**kwargs) for image in self]
             return type(self).from_images(inverted)
@@ -223,6 +258,19 @@ class SubjectsBatch(Invertible):
     stored as lists (one value per sample).
 
     Created by `SubjectsLoader` or `SubjectsBatch.from_subjects()`.
+
+    Args:
+        images: Named image batches. May be empty for metadata-only or
+            annotation-only batches.
+        points: Named subject-level point sets, stored as one `Points`
+            instance per batch element.
+        bounding_boxes: Named subject-level bounding boxes, stored as one
+            `BoundingBoxes` instance per batch element.
+        metadata: Named metadata values, stored as one value per batch
+            element.
+
+    All supplied batched fields must contain the same non-zero number of
+    elements.
     """
 
     def __init__(
@@ -345,7 +393,17 @@ class SubjectsBatch(Invertible):
         return reference
 
     def to(self, *args: Any, **kwargs: Any) -> Self:
-        """Move all data to a device and/or cast dtype."""
+        """Move all data to a device and/or cast dtype.
+
+        Args:
+            *args: Positional arguments forwarded to each field's `to`
+                method.
+            **kwargs: Keyword arguments forwarded to each field's `to`
+                method.
+
+        Returns:
+            `self` (modified in-place).
+        """
         for batch in self._images.values():
             batch.to(*args, **kwargs)
         for values in self._points.values():
@@ -357,7 +415,14 @@ class SubjectsBatch(Invertible):
         return self
 
     def __getitem__(self, key: str) -> Any:
-        """Get a named batched field."""
+        """Get a named batched field.
+
+        Args:
+            key: Image, point, bounding-box, or metadata field name.
+
+        Returns:
+            The corresponding batched field.
+        """
         for store in (
             self._images,
             self._points,
@@ -369,7 +434,14 @@ class SubjectsBatch(Invertible):
         raise KeyError(key)
 
     def __getattr__(self, name: str) -> Any:
-        """Access a named batched field as an attribute."""
+        """Access a named batched field as an attribute.
+
+        Args:
+            name: Image, point, bounding-box, or metadata field name.
+
+        Returns:
+            The corresponding batched field.
+        """
         if name.startswith("_"):
             raise AttributeError(name)
         for store in (
@@ -486,6 +558,9 @@ class SubjectsBatch(Invertible):
 
     def get_inverse_transform(self, **kwargs: Any) -> Any:
         """Build a transform that inverts the recorded history.
+
+        Args:
+            **kwargs: Forwarded to `Invertible.get_inverse_transform`.
 
         Raises:
             RuntimeError: If the batch carries per-element histories (from

--- a/src/torchio/data/batch.py
+++ b/src/torchio/data/batch.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import copy as _copy
 import dataclasses
+from collections.abc import Callable
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 from typing import Any
 
 import torch
@@ -10,9 +14,14 @@ from torch import Tensor
 from typing_extensions import Self
 
 from .affine import AffineMatrix
+from .bboxes import BoundingBoxes
 from .image import Image
 from .image import ScalarImage
 from .invertible import Invertible
+from .points import Points
+
+if TYPE_CHECKING:
+    from .subject import Subject
 
 #: Reserved param keys used for per-instance history bookkeeping.
 _BATCH_META_KEYS = ("_batch_size", "_batched_keys", "_keep")
@@ -37,35 +46,64 @@ class ImagesBatch(Invertible):
         affines: list[AffineMatrix],
         *,
         image_class: type[Image] = ScalarImage,
+        image_templates: Sequence[Image] | None = None,
     ) -> None:
         if data.ndim != 5:
             msg = f"Expected 5D tensor (B, C, I, J, K), got {data.ndim}D"
             raise ValueError(msg)
+        if data.shape[0] == 0:
+            msg = "Cannot create an empty image batch"
+            raise ValueError(msg)
         if len(affines) != data.shape[0]:
             msg = f"Expected {data.shape[0]} affines, got {len(affines)}"
+            raise ValueError(msg)
+        if not issubclass(image_class, Image):
+            msg = f"Expected an Image subclass, got {image_class!r}"
+            raise TypeError(msg)
+        if image_templates is not None and len(image_templates) != data.shape[0]:
+            msg = (
+                f"Expected {data.shape[0]} image templates, got {len(image_templates)}"
+            )
             raise ValueError(msg)
         self._data = data
         self._affines = affines
         self._image_class = image_class
+        self._image_templates = (
+            list(image_templates) if image_templates is not None else None
+        )
         self.applied_transforms: list[Any] = []
+        self._per_element_history: list[list[Any]] | None = None
 
     @classmethod
-    def from_images(cls, images: list[Image]) -> Self:
+    def from_images(cls, images: Sequence[Image]) -> Self:
         """Stack a list of images into a batch.
 
-        All images must have the same shape.
+        All images must have the same class, shape, dtype, device, and
+        nested metadata/annotation schema.
 
         Args:
-            images: List of `Image` instances to stack.
+            images: Images to stack.
         """
         if not images:
             msg = "Cannot create batch from empty list"
             raise ValueError(msg)
+        _validate_images(images)
         tensors = [img.data for img in images]
         stacked = torch.stack(tensors)
         affines = [img.affine.clone() for img in images]
         image_class = type(images[0])
-        return cls(stacked, affines, image_class=image_class)
+        templates = [_make_image_template(image) for image in images]
+        batch = cls(
+            stacked,
+            affines,
+            image_class=image_class,
+            image_templates=templates,
+        )
+        _assign_histories(
+            batch,
+            [list(image.applied_transforms) for image in images],
+        )
+        return batch
 
     @property
     def data(self) -> Tensor:
@@ -99,14 +137,27 @@ class ImagesBatch(Invertible):
         self._data = self._data.to(*args, **kwargs)
         for affine in self._affines:
             affine.to(*args, **kwargs)
+        if self._image_templates is not None:
+            for template in self._image_templates:
+                template.to(*args, **kwargs)
         return self
 
     def __getitem__(self, index: int) -> Image:
         """Get a single image from the batch by index."""
-        return self._image_class(
-            self._data[index],
-            affine=self._affines[index].clone(),
-        )
+        if self._image_templates is None:
+            image = self._image_class(
+                self._data[index],
+                affine=self._affines[index].clone(),
+            )
+        else:
+            template = self._image_templates[index]
+            image = template.new_like(
+                data=self._data[index],
+                affine=self._affines[index].clone(),
+            )
+            image._metadata = _copy.deepcopy(template.metadata)
+        image.applied_transforms = _get_element_histories(self)[index]
+        return image
 
     def __len__(self) -> int:
         return self.batch_size
@@ -114,6 +165,50 @@ class ImagesBatch(Invertible):
     def unbatch(self) -> list[Image]:
         """Split the batch into individual images."""
         return [self[i] for i in range(self.batch_size)]
+
+    @property
+    def has_annotations(self) -> bool:
+        """Whether any image has attached points or bounding boxes."""
+        if self._image_templates is None:
+            return False
+        return any(
+            template.points or template.bounding_boxes
+            for template in self._image_templates
+        )
+
+    def set_per_element_history(self, histories: list[list[Any]]) -> None:
+        """Freeze a distinct transform history for each batch element."""
+        if len(histories) != self.batch_size:
+            msg = (
+                f"Expected {self.batch_size} per-element histories,"
+                f" got {len(histories)}"
+            )
+            raise ValueError(msg)
+        self._per_element_history = [list(history) for history in histories]
+        self.applied_transforms = []
+
+    def clear_history(self) -> None:
+        """Remove all applied transform records."""
+        self.applied_transforms = []
+        self._per_element_history = None
+
+    def get_inverse_transform(self, **kwargs: Any) -> Any:
+        """Build a transform that inverts the recorded history."""
+        if self._per_element_history is not None:
+            msg = (
+                "This image batch has per-element transform histories, so a"
+                " single batch inverse is ambiguous. Call"
+                " apply_inverse_transform() or unbatch() and invert each image."
+            )
+            raise RuntimeError(msg)
+        return super().get_inverse_transform(**kwargs)
+
+    def apply_inverse_transform(self, **kwargs: Any) -> ImagesBatch:
+        """Apply the inverse of the recorded history."""
+        if self._per_element_history is not None:
+            inverted = [image.apply_inverse_transform(**kwargs) for image in self]
+            return type(self).from_images(inverted)
+        return super().apply_inverse_transform(**kwargs)
 
     def __repr__(self) -> str:
         b, c, i, j, k = self._data.shape
@@ -132,12 +227,22 @@ class SubjectsBatch(Invertible):
 
     def __init__(
         self,
-        images: dict[str, ImagesBatch],
+        images: dict[str, ImagesBatch] | None = None,
         *,
+        points: dict[str, list[Points]] | None = None,
+        bounding_boxes: dict[str, list[BoundingBoxes]] | None = None,
         metadata: dict[str, list[Any]] | None = None,
     ) -> None:
-        self._images = images
-        self._metadata: dict[str, list[Any]] = metadata or {}
+        self._images = dict(images or {})
+        self._points = dict(points or {})
+        self._bounding_boxes = dict(bounding_boxes or {})
+        self._metadata = dict(metadata or {})
+        self._batch_size = _resolve_batch_size(
+            self._images,
+            self._points,
+            self._bounding_boxes,
+            self._metadata,
+        )
         self.applied_transforms: list[Any] = []
         # When per-element branching occurs (e.g. per-instance OneOf),
         # this stores the frozen per-element history prefix. Transforms
@@ -166,40 +271,59 @@ class SubjectsBatch(Invertible):
         self.applied_transforms = []
 
     @classmethod
-    def from_subjects(cls, subjects: list[Any]) -> Self:
+    def from_subjects(cls, subjects: Sequence[Any]) -> Self:
         """Stack a list of subjects into a batch.
 
         Args:
-            subjects: List of `Subject` instances.
+            subjects: `Subject` instances to stack.
         """
         from .subject import Subject
 
         if not subjects:
             msg = "Cannot create batch from empty list"
             raise ValueError(msg)
+        for index, subject in enumerate(subjects):
+            if not isinstance(subject, Subject):
+                msg = f"Expected Subject at index {index}, got {type(subject).__name__}"
+                raise TypeError(msg)
 
-        # Collect image names and types from the first subject
         first: Subject = subjects[0]
-        image_names = list(first.images.keys())
+        _validate_subject_schemas(subjects)
 
-        # Stack images
         images: dict[str, ImagesBatch] = {}
-        for name in image_names:
+        for name in first.images:
             img_list = [sub.images[name] for sub in subjects]
             images[name] = ImagesBatch.from_images(img_list)
 
-        # Collect metadata (non-image, non-annotation entries)
-        metadata: dict[str, list[Any]] = {}
-        for key in first.metadata:
-            metadata[key] = [sub.metadata[key] for sub in subjects]
+        points = {
+            name: [_copy.deepcopy(subject.points[name]) for subject in subjects]
+            for name in first.points
+        }
+        bounding_boxes = {
+            name: [_copy.deepcopy(subject.bounding_boxes[name]) for subject in subjects]
+            for name in first.bounding_boxes
+        }
+        metadata = {
+            key: [_copy.deepcopy(subject.metadata[key]) for subject in subjects]
+            for key in first.metadata
+        }
 
-        return cls(images, metadata=metadata)
+        batch = cls(
+            images,
+            points=points,
+            bounding_boxes=bounding_boxes,
+            metadata=metadata,
+        )
+        _assign_histories(
+            batch,
+            [list(subject.applied_transforms) for subject in subjects],
+        )
+        return batch
 
     @property
     def batch_size(self) -> int:
         """Number of samples in the batch."""
-        first = next(iter(self._images.values()))
-        return first.batch_size
+        return self._batch_size
 
     @property
     def images(self) -> dict[str, ImagesBatch]:
@@ -207,32 +331,83 @@ class SubjectsBatch(Invertible):
         return self._images
 
     @property
+    def points(self) -> dict[str, list[Points]]:
+        """Dict of named point sets, one list entry per sample."""
+        return self._points
+
+    @property
+    def bounding_boxes(self) -> dict[str, list[BoundingBoxes]]:
+        """Dict of named bounding boxes, one list entry per sample."""
+        return self._bounding_boxes
+
+    @property
     def metadata(self) -> dict[str, list[Any]]:
         """Metadata lists (one value per sample)."""
         return self._metadata
 
     @property
+    def has_annotations(self) -> bool:
+        """Whether the batch contains subject- or image-level annotations."""
+        return bool(
+            self._points
+            or self._bounding_boxes
+            or any(image_batch.has_annotations for image_batch in self._images.values())
+        )
+
+    @property
     def device(self) -> torch.device:
         """Device of the batch data."""
-        first = next(iter(self._images.values()))
-        return first.device
+        devices = [image.device for image in self._images.values()]
+        devices.extend(
+            points.device for values in self._points.values() for points in values
+        )
+        devices.extend(
+            boxes.device for values in self._bounding_boxes.values() for boxes in values
+        )
+        if not devices:
+            return torch.device("cpu")
+        reference = devices[0]
+        if any(device != reference for device in devices[1:]):
+            msg = f"Inconsistent devices in SubjectsBatch: {devices}"
+            raise RuntimeError(msg)
+        return reference
 
     def to(self, *args: Any, **kwargs: Any) -> Self:
         """Move all data to a device and/or cast dtype."""
         for batch in self._images.values():
             batch.to(*args, **kwargs)
+        for values in self._points.values():
+            for points in values:
+                points.to(*args, **kwargs)
+        for values in self._bounding_boxes.values():
+            for boxes in values:
+                boxes.to(*args, **kwargs)
         return self
 
-    def __getitem__(self, key: str) -> ImagesBatch:
-        """Get a named image batch."""
-        return self._images[key]
+    def __getitem__(self, key: str) -> Any:
+        """Get a named batched field."""
+        for store in (
+            self._images,
+            self._points,
+            self._bounding_boxes,
+            self._metadata,
+        ):
+            if key in store:
+                return store[key]
+        raise KeyError(key)
 
-    def __getattr__(self, name: str) -> ImagesBatch:
-        """Attribute-style access to image batches."""
+    def __getattr__(self, name: str) -> Any:
+        """Access a named batched field as an attribute."""
         if name.startswith("_"):
             raise AttributeError(name)
-        if name in self._images:
-            return self._images[name]
+        for store in (
+            self._images,
+            self._points,
+            self._bounding_boxes,
+            self._metadata,
+        ):
+            if name in store:
+                return store[name]
         msg = f"SubjectsBatch has no attribute {name!r}"
         raise AttributeError(msg)
 
@@ -246,22 +421,65 @@ class SubjectsBatch(Invertible):
         """
         from .subject import Subject
 
-        n = self.batch_size
+        histories = _get_element_histories(self)
         subjects = []
-        for i in range(n):
+        for i in range(self.batch_size):
             kwargs: dict[str, Any] = {}
             for name, img_batch in self._images.items():
                 kwargs[name] = img_batch[i]
+            for name, values in self._points.items():
+                kwargs[name] = _copy.deepcopy(values[i])
+            for name, values in self._bounding_boxes.items():
+                kwargs[name] = _copy.deepcopy(values[i])
             for key, values in self._metadata.items():
-                kwargs[key] = values[i]
+                kwargs[key] = _copy.deepcopy(values[i])
             sub = Subject(**kwargs)
-            suffix = _slice_history(self.applied_transforms, i)
-            if self._per_element_history is not None:
-                sub.applied_transforms = list(self._per_element_history[i]) + suffix
-            else:
-                sub.applied_transforms = suffix
+            sub.applied_transforms = histories[i]
             subjects.append(sub)
         return subjects
+
+    def map_subjects(
+        self,
+        callback: Callable[[Subject], Subject],
+    ) -> Self:
+        """Apply a callback to every subject and rebuild the batch.
+
+        Each callback receives an independent `Subject` carrying its
+        complete transform history. All returned subjects must have a
+        compatible schema and image shapes so they can be re-stacked.
+        Callback-added histories are retained.
+
+        Args:
+            callback: Callable taking and returning one `Subject`.
+
+        Returns:
+            A new batch containing the callback results.
+
+        Raises:
+            TypeError: If the callback does not return a `Subject`.
+            ValueError: If callback results cannot be batched together.
+
+        Examples:
+            >>> def normalize_identifier(subject):
+            ...     subject.metadata["identifier"] = subject.identifier.strip()
+            ...     return subject
+            >>> result = batch.map_subjects(normalize_identifier)
+        """
+        from .subject import Subject
+
+        mapped = []
+        for index, subject in enumerate(self.unbatch()):
+            for image in subject.images.values():
+                image.set_data(image.data.clone())
+            result = callback(subject)
+            if not isinstance(result, Subject):
+                msg = (
+                    f"Expected callback result at index {index} to be a Subject,"
+                    f" got {type(result).__name__}"
+                )
+                raise TypeError(msg)
+            mapped.append(result)
+        return type(self).from_subjects(mapped)
 
     def __len__(self) -> int:
         return self.batch_size
@@ -278,10 +496,16 @@ class SubjectsBatch(Invertible):
             source: The batch the subjects were unbatched from.
             subjects: The processed subjects, in batch order.
         """
-        if source._per_element_history is not None:
-            self.set_per_element_history([s.applied_transforms for s in subjects])
-        else:
-            self.applied_transforms = list(source.applied_transforms)
+        if len(subjects) != source.batch_size:
+            msg = (
+                f"Expected {source.batch_size} subjects when adopting history,"
+                f" got {len(subjects)}"
+            )
+            raise ValueError(msg)
+        _assign_histories(
+            self,
+            [list(subject.applied_transforms) for subject in subjects],
+        )
 
     def clear_history(self) -> None:
         """Remove all applied transform records, including per-element ones."""
@@ -326,12 +550,286 @@ class SubjectsBatch(Invertible):
         return super().apply_inverse_transform(**kwargs)
 
     def __repr__(self) -> str:
-        names = ", ".join(self._images.keys())
-        return f"SubjectsBatch(batch_size={self.batch_size}, images=[{names}])"
+        fields = []
+        for label, store in (
+            ("images", self._images),
+            ("points", self._points),
+            ("bboxes", self._bounding_boxes),
+            ("metadata", self._metadata),
+        ):
+            if store:
+                fields.append(f"{label}=[{', '.join(store)}]")
+        return f"SubjectsBatch(batch_size={self.batch_size}, {', '.join(fields)})"
 
 
 # Alias for radiology users (see Subject/Study note in subject.py).
 StudiesBatch = SubjectsBatch
+
+
+def _make_image_template(image: Image) -> Image:
+    """Create a lightweight image carrying the per-element payload."""
+    channels = image.shape[0]
+    data = torch.empty(
+        channels,
+        1,
+        1,
+        1,
+        dtype=image.data.dtype,
+        device=image.data.device,
+    )
+    template = image.new_like(data=data, affine=image.affine)
+    template._metadata = _copy.deepcopy(image.metadata)
+    template.applied_transforms = list(image.applied_transforms)
+    return template
+
+
+def _validate_images(
+    images: Sequence[Image],
+    *,
+    image_name: str | None = None,
+) -> None:
+    """Validate image compatibility before stacking."""
+    first = images[0]
+    context = "Image" if image_name is None else f"Image {image_name!r}"
+    reference_metadata = first.metadata.keys()
+    reference_points = first.points
+    reference_boxes = first.bounding_boxes
+    for index, image in enumerate(images[1:], 1):
+        if type(image) is not type(first):
+            msg = (
+                f"{context} at index {index} is incompatible:"
+                f" expected {type(first).__name__}, got {type(image).__name__}"
+            )
+            raise ValueError(msg)
+        for attribute in ("shape", "dtype", "device"):
+            expected = getattr(first, attribute)
+            actual = getattr(image, attribute)
+            if actual != expected:
+                msg = (
+                    f"{context} at index {index} has {attribute} {actual},"
+                    f" expected {expected}"
+                )
+                raise ValueError(msg)
+        _validate_keys(
+            reference_metadata,
+            image.metadata.keys(),
+            index=index,
+            field="metadata",
+            context=context.lower(),
+        )
+        _validate_annotation_store(
+            reference_points,
+            image.points,
+            index=index,
+            field="point",
+            context=context.lower(),
+        )
+        _validate_annotation_store(
+            reference_boxes,
+            image.bounding_boxes,
+            index=index,
+            field="bounding box",
+            context=context.lower(),
+        )
+
+
+def _validate_subject_schemas(subjects: Sequence[Any]) -> None:
+    """Validate all subject and nested image schemas."""
+    first = subjects[0]
+    reference_stores = (
+        ("image", first.images),
+        ("metadata", first.metadata),
+        ("point", first.points),
+        ("bounding box", first.bounding_boxes),
+    )
+    for index, subject in enumerate(subjects[1:], 1):
+        current_stores = (
+            subject.images,
+            subject.metadata,
+            subject.points,
+            subject.bounding_boxes,
+        )
+        for (field, reference), current in zip(
+            reference_stores,
+            current_stores,
+            strict=True,
+        ):
+            _validate_keys(
+                reference.keys(),
+                current.keys(),
+                index=index,
+                field=field,
+                context="Subject",
+            )
+        for name in first.points:
+            _validate_annotation(
+                first.points[name],
+                subject.points[name],
+                index=index,
+                field="point",
+                context="Subject",
+                name=name,
+            )
+        for name in first.bounding_boxes:
+            _validate_annotation(
+                first.bounding_boxes[name],
+                subject.bounding_boxes[name],
+                index=index,
+                field="bounding box",
+                context="Subject",
+                name=name,
+            )
+    for name in first.images:
+        _validate_images(
+            [subject.images[name] for subject in subjects],
+            image_name=name,
+        )
+
+
+def _validate_annotation_store(
+    reference: dict[str, Any],
+    current: dict[str, Any],
+    *,
+    index: int,
+    field: str,
+    context: str,
+) -> None:
+    """Validate a named annotation store."""
+    _validate_keys(
+        reference.keys(),
+        current.keys(),
+        index=index,
+        field=field,
+        context=context,
+    )
+    for name in reference:
+        _validate_annotation(
+            reference[name],
+            current[name],
+            index=index,
+            field=field,
+            context=context,
+            name=name,
+        )
+
+
+def _validate_annotation(
+    reference: Points | BoundingBoxes,
+    current: Points | BoundingBoxes,
+    *,
+    index: int,
+    field: str,
+    context: str,
+    name: str,
+) -> None:
+    """Validate one named annotation's type and metadata schema."""
+    if type(current) is not type(reference):
+        msg = (
+            f"{context} at index {index} has incompatible {field} {name!r}:"
+            f" expected {type(reference).__name__}, got {type(current).__name__}"
+        )
+        raise ValueError(msg)
+    _validate_keys(
+        reference.metadata.keys(),
+        current.metadata.keys(),
+        index=index,
+        field=f"{field} {name!r} metadata",
+        context=context,
+    )
+
+
+def _validate_keys(
+    reference: Any,
+    current: Any,
+    *,
+    index: int,
+    field: str,
+    context: str,
+) -> None:
+    """Validate equivalent key sets while allowing reordered keys."""
+    reference_set = set(reference)
+    current_set = set(current)
+    if reference_set == current_set:
+        return
+    missing = sorted(reference_set - current_set)
+    unexpected = sorted(current_set - reference_set)
+    msg = (
+        f"{context} at index {index} has incompatible {field} keys:"
+        f" missing {missing}, unexpected {unexpected}"
+    )
+    raise ValueError(msg)
+
+
+def _resolve_batch_size(
+    images: dict[str, ImagesBatch],
+    points: dict[str, list[Points]],
+    bounding_boxes: dict[str, list[BoundingBoxes]],
+    metadata: dict[str, list[Any]],
+) -> int:
+    """Resolve and validate the shared length of every batched field."""
+    sizes: list[tuple[str, int]] = []
+    sizes.extend(
+        (f"image {name!r}", image_batch.batch_size)
+        for name, image_batch in images.items()
+    )
+    sizes.extend((f"point {name!r}", len(values)) for name, values in points.items())
+    sizes.extend(
+        (f"bounding box {name!r}", len(values))
+        for name, values in bounding_boxes.items()
+    )
+    sizes.extend(
+        (f"metadata {name!r}", len(values)) for name, values in metadata.items()
+    )
+    if not sizes:
+        msg = "A SubjectsBatch must contain at least one batched field"
+        raise ValueError(msg)
+    reference_name, reference_size = sizes[0]
+    if reference_size == 0:
+        msg = "Cannot create an empty SubjectsBatch"
+        raise ValueError(msg)
+    for name, size in sizes[1:]:
+        if size != reference_size:
+            msg = (
+                f"Inconsistent batch size: {reference_name} has"
+                f" {reference_size} elements, but {name} has {size}"
+            )
+            raise ValueError(msg)
+    return reference_size
+
+
+def _histories_equal(first: list[Any], second: list[Any]) -> bool:
+    """Compare histories, conservatively treating ambiguous equality as false."""
+    try:
+        return bool(first == second)
+    except (RuntimeError, TypeError, ValueError):
+        return False
+
+
+def _assign_histories(batch: Any, histories: Sequence[list[Any]]) -> None:
+    """Store histories in shared or per-element form."""
+    copied = [list(history) for history in histories]
+    if not copied:
+        batch.applied_transforms = []
+        batch._per_element_history = None
+        return
+    first = copied[0]
+    if all(_histories_equal(first, history) for history in copied[1:]):
+        batch.applied_transforms = list(first)
+        batch._per_element_history = None
+    else:
+        batch.set_per_element_history(copied)
+
+
+def _get_element_histories(batch: Any) -> list[list[Any]]:
+    """Return each element's complete history."""
+    histories = []
+    for index in range(batch.batch_size):
+        suffix = _slice_history(batch.applied_transforms, index)
+        if batch._per_element_history is None:
+            histories.append(suffix)
+        else:
+            histories.append(list(batch._per_element_history[index]) + suffix)
+    return histories
 
 
 def _slice_params(

--- a/src/torchio/data/batch.py
+++ b/src/torchio/data/batch.py
@@ -156,7 +156,7 @@ class ImagesBatch(Invertible):
                 affine=self._affines[index].clone(),
             )
             image._metadata = _copy.deepcopy(template.metadata)
-        image.applied_transforms = _get_element_histories(self)[index]
+        image.applied_transforms = _get_element_history(self, index)
         return image
 
     def __len__(self) -> int:
@@ -822,14 +822,15 @@ def _assign_histories(batch: Any, histories: Sequence[list[Any]]) -> None:
 
 def _get_element_histories(batch: Any) -> list[list[Any]]:
     """Return each element's complete history."""
-    histories = []
-    for index in range(batch.batch_size):
-        suffix = _slice_history(batch.applied_transforms, index)
-        if batch._per_element_history is None:
-            histories.append(suffix)
-        else:
-            histories.append(list(batch._per_element_history[index]) + suffix)
-    return histories
+    return [_get_element_history(batch, index) for index in range(batch.batch_size)]
+
+
+def _get_element_history(batch: Any, index: int) -> list[Any]:
+    """Return one element's complete history."""
+    suffix = _slice_history(batch.applied_transforms, index)
+    if batch._per_element_history is None:
+        return suffix
+    return list(batch._per_element_history[index]) + suffix
 
 
 def _slice_params(

--- a/src/torchio/data/bboxes.py
+++ b/src/torchio/data/bboxes.py
@@ -312,6 +312,10 @@ class BoundingBoxes:
     def to(self, *args: Any, **kwargs: Any) -> Self:
         """Move bounding box data and affine to a device or dtype.
 
+        Args:
+            *args: Positional arguments forwarded to `torch.Tensor.to`.
+            **kwargs: Keyword arguments forwarded to `torch.Tensor.to`.
+
         Returns:
             `self` (modified in-place).
         """

--- a/src/torchio/data/bboxes.py
+++ b/src/torchio/data/bboxes.py
@@ -310,7 +310,7 @@ class BoundingBoxes:
         return self._data.device
 
     def to(self, *args: Any, **kwargs: Any) -> Self:
-        """Move bounding box data to a device and/or cast to a dtype.
+        """Move bounding box data and affine to a device or dtype.
 
         Returns:
             `self` (modified in-place).
@@ -318,6 +318,7 @@ class BoundingBoxes:
         self._data = self._data.to(*args, **kwargs)
         if self._labels is not None:
             self._labels = self._labels.to(*args, **kwargs)
+        self._affine.to(*args, **kwargs)
         return self
 
     # --- Methods ---

--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -646,6 +646,10 @@ class Image(Invertible):
 
         Accepts the same arguments as `torch.Tensor.to()`.
 
+        Args:
+            *args: Positional arguments forwarded to `torch.Tensor.to`.
+            **kwargs: Keyword arguments forwarded to `torch.Tensor.to`.
+
         Returns:
             `self` (modified in-place).
         """

--- a/src/torchio/data/image.py
+++ b/src/torchio/data/image.py
@@ -642,7 +642,7 @@ class Image(Invertible):
         return self.data.device
 
     def to(self, *args: Any, **kwargs: Any) -> Self:
-        """Move image data and affine to a device and/or cast to a dtype.
+        """Move image data, affine, and annotations to a device or dtype.
 
         Accepts the same arguments as `torch.Tensor.to()`.
 
@@ -652,6 +652,10 @@ class Image(Invertible):
         self._data = self.data.to(*args, **kwargs)
         if self._affine is not None:
             self._affine.to(*args, **kwargs)
+        for points in self._points.values():
+            points.to(*args, **kwargs)
+        for boxes in self._bounding_boxes.values():
+            boxes.to(*args, **kwargs)
         self._refresh_backend_from_data()
         return self
 

--- a/src/torchio/data/points.py
+++ b/src/torchio/data/points.py
@@ -110,6 +110,10 @@ class Points:
     def to(self, *args: Any, **kwargs: Any) -> Self:
         """Move point data and affine to a device or dtype.
 
+        Args:
+            *args: Positional arguments forwarded to `torch.Tensor.to`.
+            **kwargs: Keyword arguments forwarded to `torch.Tensor.to`.
+
         Returns:
             `self` (modified in-place).
         """

--- a/src/torchio/data/points.py
+++ b/src/torchio/data/points.py
@@ -108,12 +108,13 @@ class Points:
         return self._data.device
 
     def to(self, *args: Any, **kwargs: Any) -> Self:
-        """Move point data to a device and/or cast to a dtype.
+        """Move point data and affine to a device or dtype.
 
         Returns:
             `self` (modified in-place).
         """
         self._data = self._data.to(*args, **kwargs)
+        self._affine.to(*args, **kwargs)
         return self
 
     # --- Methods ---

--- a/src/torchio/transforms/spatial/crop_or_pad.py
+++ b/src/torchio/transforms/spatial/crop_or_pad.py
@@ -468,8 +468,8 @@ class CropOrPad(SpatialTransform):
         without loading data from disk. For batched inputs, falls back
         to the standard `SubjectsBatch` path.
         """
-        self._check_spatial_annotations(data)
         if isinstance(data, (Subject, Image)):
+            self._check_spatial_annotations(data)
             return self._forward_lazy(data)
         return super().forward(data)
 

--- a/src/torchio/transforms/spatial/crop_or_pad.py
+++ b/src/torchio/transforms/spatial/crop_or_pad.py
@@ -468,6 +468,7 @@ class CropOrPad(SpatialTransform):
         without loading data from disk. For batched inputs, falls back
         to the standard `SubjectsBatch` path.
         """
+        self._check_spatial_annotations(data)
         if isinstance(data, (Subject, Image)):
             return self._forward_lazy(data)
         return super().forward(data)

--- a/src/torchio/transforms/spatial/ensure_shape_multiple.py
+++ b/src/torchio/transforms/spatial/ensure_shape_multiple.py
@@ -114,6 +114,7 @@ class EnsureShapeMultiple(SpatialTransform):
         For `Subject` and `Image` inputs, delegates to `CropOrPad`
         for lazy operation without loading data from disk.
         """
+        self._check_spatial_annotations(data)
         if isinstance(data, (Subject, Image)):
             return self._build_crop_or_pad(data).forward(data)
         return super().forward(data)

--- a/src/torchio/transforms/spatial/ensure_shape_multiple.py
+++ b/src/torchio/transforms/spatial/ensure_shape_multiple.py
@@ -114,7 +114,6 @@ class EnsureShapeMultiple(SpatialTransform):
         For `Subject` and `Image` inputs, delegates to `CropOrPad`
         for lazy operation without loading data from disk.
         """
-        self._check_spatial_annotations(data)
         if isinstance(data, (Subject, Image)):
             return self._build_crop_or_pad(data).forward(data)
         return super().forward(data)

--- a/src/torchio/transforms/transform.py
+++ b/src/torchio/transforms/transform.py
@@ -23,8 +23,10 @@ from ..data.batch import ImagesBatch
 from ..data.batch import SubjectsBatch
 from ..data.batch import _assign_histories
 from ..data.batch import _get_element_histories
+from ..data.bboxes import BoundingBoxes
 from ..data.image import Image
 from ..data.image import ScalarImage
+from ..data.points import Points
 from ..data.subject import Subject
 
 
@@ -277,6 +279,15 @@ class Transform(nn.Module):
                 )
             case Image():
                 has_annotations = bool(data.points or data.bounding_boxes)
+            case dict():
+                has_annotations = any(
+                    isinstance(value, (Points, BoundingBoxes))
+                    or (
+                        isinstance(value, Image)
+                        and bool(value.points or value.bounding_boxes)
+                    )
+                    for value in data.values()
+                )
             case _:
                 has_annotations = False
         if has_annotations:

--- a/src/torchio/transforms/transform.py
+++ b/src/torchio/transforms/transform.py
@@ -21,6 +21,8 @@ from torch import nn
 
 from ..data.batch import ImagesBatch
 from ..data.batch import SubjectsBatch
+from ..data.batch import _assign_histories
+from ..data.batch import _get_element_histories
 from ..data.image import Image
 from ..data.image import ScalarImage
 from ..data.subject import Subject
@@ -217,6 +219,7 @@ class Transform(nn.Module):
         Args:
             data: Input data to transform.
         """
+        self._check_spatial_annotations(data)
         if self.copy:
             data = _copy.deepcopy(data)
         batch, unwrap = self._wrap(data)
@@ -246,12 +249,43 @@ class Transform(nn.Module):
         # Propagate history to outputs that can carry it
         if (
             hasattr(batch, "applied_transforms")
-            and not isinstance(result, (SubjectsBatch, Tensor, np.ndarray))
+            and not isinstance(
+                result,
+                (ImagesBatch, SubjectsBatch, Tensor, np.ndarray),
+            )
             and not isinstance(result, dict)
         ):
             with contextlib.suppress(AttributeError):
                 result.applied_transforms = list(batch.applied_transforms)
         return result
+
+    def _check_spatial_annotations(self, data: Any) -> None:
+        """Reject spatial transforms that would leave stale annotations."""
+        if not isinstance(self, SpatialTransform):
+            return
+        match data:
+            case SubjectsBatch() | ImagesBatch():
+                has_annotations = data.has_annotations
+            case Subject():
+                has_annotations = bool(
+                    data.points
+                    or data.bounding_boxes
+                    or any(
+                        image.points or image.bounding_boxes
+                        for image in data.images.values()
+                    )
+                )
+            case Image():
+                has_annotations = bool(data.points or data.bounding_boxes)
+            case _:
+                has_annotations = False
+        if has_annotations:
+            msg = (
+                "Spatial transforms do not yet support Points or BoundingBoxes."
+                " Remove the annotations before applying the transform, or apply"
+                " an annotation-aware spatial operation."
+            )
+            raise NotImplementedError(msg)
 
     @property
     def supports_per_instance_params(self) -> bool:
@@ -497,6 +531,7 @@ class Transform(nn.Module):
                 return data, _unwrap_subjects_batch
             case ImagesBatch():
                 sb = SubjectsBatch({"tio_default_image": data})
+                _assign_histories(sb, _get_element_histories(data))
                 return sb, _unwrap_images_batch
             case Subject():
                 sb = SubjectsBatch.from_subjects([data])
@@ -512,6 +547,7 @@ def _wrap_single_image(img: Image, unwrap_fn: Any) -> tuple[Any, Any]:
     from ..data.batch import SubjectsBatch
 
     sub = Subject(tio_default_image=img)
+    sub.applied_transforms = list(img.applied_transforms)
     sb = SubjectsBatch.from_subjects([sub])
     return sb, unwrap_fn
 
@@ -607,7 +643,9 @@ def _unwrap_subjects_batch(batch: SubjectsBatch) -> SubjectsBatch:
 
 
 def _unwrap_images_batch(batch: SubjectsBatch) -> ImagesBatch:
-    return batch.images["tio_default_image"]
+    image_batch = batch.images["tio_default_image"]
+    _assign_histories(image_batch, _get_element_histories(batch))
+    return image_batch
 
 
 def _unwrap_subject(batch: SubjectsBatch) -> Subject:
@@ -616,7 +654,9 @@ def _unwrap_subject(batch: SubjectsBatch) -> Subject:
 
 def _unwrap_image(batch: SubjectsBatch) -> Image:
     sub = batch.unbatch()[0]
-    return sub.tio_default_image
+    image = sub.tio_default_image
+    image.applied_transforms = list(sub.applied_transforms)
+    return image
 
 
 def _unwrap_tensor(batch: SubjectsBatch) -> Tensor:

--- a/src/torchio/transforms/transform.py
+++ b/src/torchio/transforms/transform.py
@@ -70,6 +70,40 @@ def _copy_optional_list(value: list[str] | None) -> list[str] | None:
     return None if value is None else list(value)
 
 
+def _image_has_annotations(image: Image) -> bool:
+    return bool(image.points or image.bounding_boxes)
+
+
+def _subject_has_annotations(subject: Subject) -> bool:
+    return bool(
+        subject.points
+        or subject.bounding_boxes
+        or any(_image_has_annotations(image) for image in subject.images.values())
+    )
+
+
+def _value_has_annotations(value: Any) -> bool:
+    if isinstance(value, (Points, BoundingBoxes)):
+        return True
+    if isinstance(value, Image):
+        return _image_has_annotations(value)
+    return False
+
+
+def _data_has_annotations(data: Any) -> bool:
+    match data:
+        case SubjectsBatch() | ImagesBatch():
+            return data.has_annotations
+        case Subject():
+            return _subject_has_annotations(data)
+        case Image():
+            return _image_has_annotations(data)
+        case dict():
+            return any(_value_has_annotations(value) for value in data.values())
+        case _:
+            return False
+
+
 class Transform(nn.Module):
     """Abstract class for all TorchIO transforms.
 
@@ -263,34 +297,7 @@ class Transform(nn.Module):
 
     def _check_spatial_annotations(self, data: Any) -> None:
         """Reject spatial transforms that would leave stale annotations."""
-        if not isinstance(self, SpatialTransform):
-            return
-        match data:
-            case SubjectsBatch() | ImagesBatch():
-                has_annotations = data.has_annotations
-            case Subject():
-                has_annotations = bool(
-                    data.points
-                    or data.bounding_boxes
-                    or any(
-                        image.points or image.bounding_boxes
-                        for image in data.images.values()
-                    )
-                )
-            case Image():
-                has_annotations = bool(data.points or data.bounding_boxes)
-            case dict():
-                has_annotations = any(
-                    isinstance(value, (Points, BoundingBoxes))
-                    or (
-                        isinstance(value, Image)
-                        and bool(value.points or value.bounding_boxes)
-                    )
-                    for value in data.values()
-                )
-            case _:
-                has_annotations = False
-        if has_annotations:
+        if isinstance(self, SpatialTransform) and _data_has_annotations(data):
             msg = (
                 "Spatial transforms do not yet support Points or BoundingBoxes."
                 " Remove the annotations before applying the transform, or apply"

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -107,6 +107,14 @@ class TestImagesBatch:
         assert restored.points["landmarks"].data.dtype == torch.float64
         assert restored.bounding_boxes["tumors"].data.dtype == torch.float64
 
+    def test_template_does_not_share_original_affine(self) -> None:
+        image = tio.ScalarImage(torch.rand(1, 4, 4, 4))
+
+        batch = ImagesBatch.from_images([image])
+
+        assert batch._image_templates is not None
+        assert batch._image_templates[0].affine is not image.affine
+
 
 class TestSubjectsBatch:
     def test_from_subjects(self) -> None:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -67,6 +67,29 @@ class TestImagesBatch:
         assert "4" in repr(batch)
         assert "8" in repr(batch)
 
+    def test_payload_and_history_round_trip(self) -> None:
+        images = [
+            tio.ScalarImage(
+                torch.rand(1, 4, 4, 4),
+                protocol=f"protocol-{index}",
+                points={"landmarks": tio.Points(torch.rand(index + 1, 3))},
+            )
+            for index in range(2)
+        ]
+        images[0].applied_transforms = [tio.AppliedTransform("Flip", {"axes": (0,)})]
+        images[1].applied_transforms = [tio.AppliedTransform("Flip", {"axes": (1,)})]
+
+        restored = ImagesBatch.from_images(images).unbatch()
+
+        assert [image.protocol for image in restored] == [
+            "protocol-0",
+            "protocol-1",
+        ]
+        assert restored[0].points["landmarks"].num_points == 1
+        assert restored[1].points["landmarks"].num_points == 2
+        assert restored[0].applied_transforms[0].params["axes"] == (0,)
+        assert restored[1].applied_transforms[0].params["axes"] == (1,)
+
 
 class TestSubjectsBatch:
     def test_from_subjects(self) -> None:
@@ -142,6 +165,241 @@ class TestSubjectsBatch:
         assert batch.metadata["age"] == [42, 43, 44]
         assert batch.metadata["name"] == ["sub_0", "sub_1", "sub_2"]
 
+    def test_reordered_schema_is_accepted(self) -> None:
+        first = tio.Subject(
+            t1=tio.ScalarImage(torch.rand(1, 8, 8, 8)),
+            seg=tio.LabelMap(torch.zeros(1, 8, 8, 8)),
+            age=42,
+            name="first",
+        )
+        second = tio.Subject(
+            seg=tio.LabelMap(torch.zeros(1, 8, 8, 8)),
+            t1=tio.ScalarImage(torch.rand(1, 8, 8, 8)),
+            name="second",
+            age=43,
+        )
+
+        batch = SubjectsBatch.from_subjects([first, second])
+
+        assert list(batch.images) == ["t1", "seg"]
+        assert list(batch.metadata) == ["age", "name"]
+
+    @pytest.mark.parametrize(
+        ("first", "second", "message"),
+        [
+            (
+                tio.Subject(t1=tio.ScalarImage(torch.rand(1, 4, 4, 4))),
+                tio.Subject(
+                    t1=tio.ScalarImage(torch.rand(1, 4, 4, 4)),
+                    t2=tio.ScalarImage(torch.rand(1, 4, 4, 4)),
+                ),
+                "image.*unexpected.*t2",
+            ),
+            (
+                tio.Subject(
+                    t1=tio.ScalarImage(torch.rand(1, 4, 4, 4)),
+                    age=42,
+                ),
+                tio.Subject(t1=tio.ScalarImage(torch.rand(1, 4, 4, 4))),
+                "metadata.*missing.*age",
+            ),
+            (
+                tio.Subject(
+                    t1=tio.ScalarImage(torch.rand(1, 4, 4, 4)),
+                    landmarks=tio.Points(torch.rand(2, 3)),
+                ),
+                tio.Subject(t1=tio.ScalarImage(torch.rand(1, 4, 4, 4))),
+                "point.*missing.*landmarks",
+            ),
+            (
+                tio.Subject(
+                    t1=tio.ScalarImage(torch.rand(1, 4, 4, 4)),
+                    tumors=tio.BoundingBoxes(
+                        torch.rand(2, 6),
+                        format=tio.BoundingBoxFormat.IJKIJK,
+                    ),
+                ),
+                tio.Subject(t1=tio.ScalarImage(torch.rand(1, 4, 4, 4))),
+                "bounding box.*missing.*tumors",
+            ),
+        ],
+    )
+    def test_incompatible_subject_schema_raises(
+        self,
+        first: tio.Subject,
+        second: tio.Subject,
+        message: str,
+    ) -> None:
+        with pytest.raises(ValueError, match=message):
+            SubjectsBatch.from_subjects([first, second])
+
+    def test_mixed_image_classes_raise(self) -> None:
+        subjects = [
+            tio.Subject(t1=tio.ScalarImage(torch.rand(1, 4, 4, 4))),
+            tio.Subject(t1=tio.LabelMap(torch.zeros(1, 4, 4, 4))),
+        ]
+        with pytest.raises(ValueError, match=r"index 1.*ScalarImage.*LabelMap"):
+            SubjectsBatch.from_subjects(subjects)
+
+    def test_mismatched_image_shapes_raise(self) -> None:
+        subjects = [
+            tio.Subject(t1=tio.ScalarImage(torch.rand(1, 4, 4, 4))),
+            tio.Subject(t1=tio.ScalarImage(torch.rand(1, 5, 4, 4))),
+        ]
+        with pytest.raises(ValueError, match=r"index 1.*shape"):
+            SubjectsBatch.from_subjects(subjects)
+
+    def test_mismatched_image_dtypes_raise(self) -> None:
+        subjects = [
+            tio.Subject(t1=tio.ScalarImage(torch.rand(1, 4, 4, 4))),
+            tio.Subject(
+                t1=tio.ScalarImage(torch.rand(1, 4, 4, 4, dtype=torch.float64))
+            ),
+        ]
+        with pytest.raises(ValueError, match=r"index 1.*dtype"):
+            SubjectsBatch.from_subjects(subjects)
+
+    def test_metadata_only_batch(self) -> None:
+        batch = SubjectsBatch.from_subjects(
+            [
+                tio.Subject(age=42, name="first"),
+                tio.Subject(age=43, name="second"),
+            ]
+        )
+
+        assert batch.batch_size == 2
+        assert batch.device.type == "cpu"
+        assert batch.metadata == {
+            "age": [42, 43],
+            "name": ["first", "second"],
+        }
+        assert [subject.age for subject in batch.unbatch()] == [42, 43]
+
+    def test_annotation_only_batch(self) -> None:
+        subjects = [
+            tio.Subject(
+                landmarks=tio.Points(torch.rand(index + 1, 3)),
+                tumors=tio.BoundingBoxes(
+                    torch.rand(index + 1, 6),
+                    format=tio.BoundingBoxFormat.IJKIJK,
+                ),
+            )
+            for index in range(2)
+        ]
+
+        batch = SubjectsBatch.from_subjects(subjects)
+        restored = batch.to(torch.float64).unbatch()
+
+        assert batch.batch_size == 2
+        assert restored[0].landmarks.data.dtype == torch.float64
+        assert restored[1].tumors.data.dtype == torch.float64
+        assert restored[0].landmarks.num_points == 1
+        assert restored[1].tumors.num_boxes == 2
+
+    def test_subject_annotations_round_trip(self) -> None:
+        subject = tio.Subject(
+            t1=tio.ScalarImage(torch.rand(1, 4, 4, 4)),
+            landmarks=tio.Points(
+                torch.rand(2, 3),
+                metadata={"source": "manual"},
+            ),
+            tumors=tio.BoundingBoxes(
+                torch.rand(3, 6),
+                format=tio.BoundingBoxFormat.IJKWHD,
+                metadata={"reader": "test"},
+            ),
+        )
+
+        restored = SubjectsBatch.from_subjects([subject]).unbatch()[0]
+
+        assert restored.landmarks.metadata == {"source": "manual"}
+        assert restored.tumors.metadata == {"reader": "test"}
+        assert restored.tumors.format == tio.BoundingBoxFormat.IJKWHD
+
+    def test_image_payload_round_trip(self) -> None:
+        image = tio.ScalarImage(
+            torch.rand(1, 4, 4, 4),
+            protocol="MPRAGE",
+            points={"landmarks": tio.Points(torch.rand(2, 3))},
+            bounding_boxes={
+                "tumors": tio.BoundingBoxes(
+                    torch.rand(2, 6),
+                    format=tio.BoundingBoxFormat.IJKIJK,
+                )
+            },
+        )
+        subject = tio.Subject(t1=image)
+
+        restored = SubjectsBatch.from_subjects([subject]).unbatch()[0].t1
+
+        assert restored.metadata == {"protocol": "MPRAGE"}
+        assert set(restored.points) == {"landmarks"}
+        assert set(restored.bounding_boxes) == {"tumors"}
+
+    def test_image_nested_schema_mismatch_raises(self) -> None:
+        subjects = [
+            tio.Subject(
+                t1=tio.ScalarImage(
+                    torch.rand(1, 4, 4, 4),
+                    protocol="MPRAGE",
+                )
+            ),
+            tio.Subject(t1=tio.ScalarImage(torch.rand(1, 4, 4, 4))),
+        ]
+
+        with pytest.raises(
+            ValueError,
+            match=r"image 't1'.*metadata.*missing.*protocol",
+        ):
+            SubjectsBatch.from_subjects(subjects)
+
+    def test_custom_image_subclass_round_trip(self) -> None:
+        class CustomScalarImage(tio.ScalarImage):
+            pass
+
+        subjects = [
+            tio.Subject(
+                t1=CustomScalarImage(
+                    torch.rand(1, 4, 4, 4),
+                    sequence="custom",
+                )
+            )
+            for _ in range(2)
+        ]
+
+        restored = SubjectsBatch.from_subjects(subjects).unbatch()
+
+        assert all(type(subject.t1) is CustomScalarImage for subject in restored)
+        assert all(subject.t1.sequence == "custom" for subject in restored)
+
+    def test_shared_history_round_trip(self) -> None:
+        trace = tio.AppliedTransform("Flip", {"axes": (0,)})
+        subjects = [
+            tio.Subject(t1=tio.ScalarImage(torch.rand(1, 4, 4, 4))) for _ in range(2)
+        ]
+        for subject in subjects:
+            subject.applied_transforms = [trace]
+
+        batch = SubjectsBatch.from_subjects(subjects)
+
+        assert batch._per_element_history is None
+        assert batch.applied_transforms == [trace]
+        assert all(subject.applied_transforms == [trace] for subject in batch.unbatch())
+
+    def test_divergent_history_round_trip(self) -> None:
+        subjects = [
+            tio.Subject(t1=tio.ScalarImage(torch.rand(1, 4, 4, 4))) for _ in range(2)
+        ]
+        subjects[0].applied_transforms = [tio.AppliedTransform("Flip", {"axes": (0,)})]
+        subjects[1].applied_transforms = [tio.AppliedTransform("Flip", {"axes": (1,)})]
+
+        batch = SubjectsBatch.from_subjects(subjects)
+        restored = batch.unbatch()
+
+        assert batch._per_element_history is not None
+        assert restored[0].applied_transforms[0].params["axes"] == (0,)
+        assert restored[1].applied_transforms[0].params["axes"] == (1,)
+
 
 class TestBatchTransforms:
     def test_flip_images_batch(self) -> None:
@@ -195,6 +453,47 @@ class TestBatchTransforms:
         tio.Noise(std=1.0)(batch)
         # Original should be unchanged (copy=True default)
         torch.testing.assert_close(batch.data, original)
+
+    def test_intensity_transform_preserves_annotations(self) -> None:
+        subject = tio.Subject(
+            t1=tio.ScalarImage(
+                torch.rand(1, 4, 4, 4) + 0.1,
+                points={"image_landmarks": tio.Points(torch.rand(2, 3))},
+            ),
+            landmarks=tio.Points(torch.rand(3, 3)),
+        )
+
+        result = tio.Gamma(log_gamma=0.2)(subject)
+
+        assert set(result.points) == {"landmarks"}
+        assert set(result.t1.points) == {"image_landmarks"}
+
+    @pytest.mark.parametrize(
+        "subject",
+        [
+            tio.Subject(
+                t1=tio.ScalarImage(torch.rand(1, 4, 4, 4)),
+                landmarks=tio.Points(torch.rand(2, 3)),
+            ),
+            tio.Subject(
+                t1=tio.ScalarImage(
+                    torch.rand(1, 4, 4, 4),
+                    bounding_boxes={
+                        "tumors": tio.BoundingBoxes(
+                            torch.rand(2, 6),
+                            format=tio.BoundingBoxFormat.IJKIJK,
+                        )
+                    },
+                )
+            ),
+        ],
+    )
+    def test_spatial_transform_rejects_annotations(
+        self,
+        subject: tio.Subject,
+    ) -> None:
+        with pytest.raises(NotImplementedError, match="annotations"):
+            tio.Flip(axes=(0,))(subject)
 
 
 # ── Coverage gap tests ───────────────────────────────────────────────
@@ -334,3 +633,115 @@ class TestPerElementHistory:
         assert rebuilt._per_element_history is None
         for subject in rebuilt.unbatch():
             assert [t.name for t in subject.applied_transforms] == ["Gamma"]
+
+
+class TestMapSubjects:
+    def _batch(self) -> SubjectsBatch:
+        return SubjectsBatch.from_subjects(
+            [
+                tio.Subject(
+                    t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4)),
+                    identifier=f" subject-{index} ",
+                    index=index,
+                )
+                for index in range(2)
+            ]
+        )
+
+    def test_maps_text_metadata(self) -> None:
+        batch = self._batch()
+
+        def strip_identifier(subject: tio.Subject) -> tio.Subject:
+            subject.metadata["identifier"] = subject.identifier.strip()
+            return subject
+
+        result = batch.map_subjects(strip_identifier)
+
+        assert result.metadata["identifier"] == ["subject-0", "subject-1"]
+        assert batch.metadata["identifier"] == [" subject-0 ", " subject-1 "]
+
+    def test_preserves_annotations(self) -> None:
+        batch = SubjectsBatch.from_subjects(
+            [
+                tio.Subject(
+                    landmarks=tio.Points(torch.rand(index + 1, 3)),
+                    identifier=f"subject-{index}",
+                )
+                for index in range(2)
+            ]
+        )
+
+        result = batch.map_subjects(lambda subject: subject)
+
+        assert result.points["landmarks"][0].num_points == 1
+        assert result.points["landmarks"][1].num_points == 2
+
+    def test_allows_uniform_schema_change(self) -> None:
+        def add_site(subject: tio.Subject) -> tio.Subject:
+            subject.metadata["site"] = "A"
+            return subject
+
+        result = self._batch().map_subjects(add_site)
+
+        assert result.metadata["site"] == ["A", "A"]
+
+    def test_rejects_divergent_schema_change(self) -> None:
+        def add_site_to_first(subject: tio.Subject) -> tio.Subject:
+            if subject.index == 0:
+                subject.metadata["site"] = "A"
+            return subject
+
+        with pytest.raises(ValueError, match=r"index 1.*metadata.*missing.*site"):
+            self._batch().map_subjects(add_site_to_first)
+
+    def test_rejects_non_subject_result(self) -> None:
+        def return_dict(subject: tio.Subject) -> dict:
+            return {"subject": subject}
+
+        with pytest.raises(TypeError, match=r"index 0.*Subject.*dict"):
+            self._batch().map_subjects(return_dict)  # type: ignore[arg-type]
+
+    def test_retains_shared_callback_history(self) -> None:
+        def flip(subject: tio.Subject) -> tio.Subject:
+            return tio.Flip(axes=(0,))(subject)
+
+        result = self._batch().map_subjects(flip)
+
+        assert result._per_element_history is None
+        assert [trace.name for trace in result.applied_transforms] == ["Flip"]
+
+    def test_retains_shared_history_with_tensor_params(self) -> None:
+        batch = self._batch()
+        trace = tio.AppliedTransform(
+            "Custom",
+            {"value": torch.tensor([1, 2])},
+        )
+        batch.applied_transforms = [trace]
+
+        result = batch.map_subjects(lambda subject: subject)
+
+        assert result._per_element_history is None
+        assert result.applied_transforms == [trace]
+
+    def test_retains_divergent_callback_history(self) -> None:
+        def flip_by_index(subject: tio.Subject) -> tio.Subject:
+            return tio.Flip(axes=(subject.index,))(subject)
+
+        result = self._batch().map_subjects(flip_by_index)
+        histories = [subject.applied_transforms for subject in result.unbatch()]
+
+        assert result._per_element_history is not None
+        assert histories[0][0].params["axes"] == (0,)
+        assert histories[1][0].params["axes"] == (1,)
+
+    def test_in_place_callback_does_not_mutate_input(self) -> None:
+        batch = self._batch()
+
+        def add_in_place(subject: tio.Subject) -> tio.Subject:
+            subject.t1.data.add_(1)
+            return subject
+
+        result = batch.map_subjects(add_in_place)
+
+        assert torch.count_nonzero(batch.t1.data) == 0
+        assert torch.all(result.t1.data == 1)

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -469,7 +469,7 @@ class TestBatchTransforms:
         assert set(result.t1.points) == {"image_landmarks"}
 
     @pytest.mark.parametrize(
-        "subject",
+        "data",
         [
             tio.Subject(
                 t1=tio.ScalarImage(torch.rand(1, 4, 4, 4)),
@@ -486,14 +486,24 @@ class TestBatchTransforms:
                     },
                 )
             ),
+            {
+                "t1": torch.rand(1, 4, 4, 4),
+                "landmarks": tio.Points(torch.rand(2, 3)),
+            },
+            {
+                "t1": tio.ScalarImage(
+                    torch.rand(1, 4, 4, 4),
+                    points={"landmarks": tio.Points(torch.rand(2, 3))},
+                )
+            },
         ],
     )
     def test_spatial_transform_rejects_annotations(
         self,
-        subject: tio.Subject,
+        data: object,
     ) -> None:
         with pytest.raises(NotImplementedError, match="annotations"):
-            tio.Flip(axes=(0,))(subject)
+            tio.Flip(axes=(0,))(data)
 
 
 # ── Coverage gap tests ───────────────────────────────────────────────

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -90,6 +90,23 @@ class TestImagesBatch:
         assert restored[0].applied_transforms[0].params["axes"] == (0,)
         assert restored[1].applied_transforms[0].params["axes"] == (1,)
 
+    def test_to_moves_template_annotations(self) -> None:
+        image = tio.ScalarImage(
+            torch.rand(1, 4, 4, 4),
+            points={"landmarks": tio.Points(torch.rand(2, 3))},
+            bounding_boxes={
+                "tumors": tio.BoundingBoxes(
+                    torch.rand(2, 6),
+                    format=tio.BoundingBoxFormat.IJKIJK,
+                )
+            },
+        )
+
+        restored = ImagesBatch.from_images([image]).to(torch.float64).unbatch()[0]
+
+        assert restored.points["landmarks"].data.dtype == torch.float64
+        assert restored.bounding_boxes["tumors"].data.dtype == torch.float64
+
 
 class TestSubjectsBatch:
     def test_from_subjects(self) -> None:

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -536,6 +536,16 @@ class TestImagesBatchValidation:
         with pytest.raises(ValueError, match="empty"):
             ImagesBatch.from_images([])
 
+    def test_non_class_image_class_raises_clear_error(self) -> None:
+        image = tio.ScalarImage(torch.rand(1, 5, 5, 5))
+
+        with pytest.raises(TypeError, match="Image subclass"):
+            ImagesBatch(
+                data=torch.rand(1, 1, 5, 5, 5),
+                affines=[tio.AffineMatrix()],
+                image_class=image,  # type: ignore[arg-type]
+            )
+
     def test_data_setter_non_5d_raises(self) -> None:
         from torchio.data.batch import ImagesBatch
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -29,6 +29,23 @@ class TestImageTo:
         result = image.to(torch.float16)
         assert result.data.dtype == torch.float16
 
+    def test_moves_image_annotations(self) -> None:
+        image = tio.ScalarImage(
+            torch.rand(1, 4, 4, 4),
+            points={"landmarks": Points(torch.rand(2, 3))},
+            bounding_boxes={
+                "tumors": BoundingBoxes(
+                    torch.rand(2, 6),
+                    format=BoundingBoxFormat.IJKIJK,
+                )
+            },
+        )
+
+        result = image.to(torch.float64)
+
+        assert result.points["landmarks"].data.dtype == torch.float64
+        assert result.bounding_boxes["tumors"].data.dtype == torch.float64
+
     @pytest.mark.skipif(not HAS_CUDA, reason="No CUDA")
     def test_to_cuda(self) -> None:
         image = tio.ScalarImage(torch.rand(1, 4, 4, 4))

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -14,6 +14,27 @@ HAS_CUDA = torch.cuda.is_available()
 HAS_MPS = torch.backends.mps.is_available()
 
 
+class TestAnnotationTo:
+    def test_points_to_moves_affine(self) -> None:
+        points = Points(torch.rand(2, 3))
+
+        points.to("meta")
+
+        assert points.device.type == "meta"
+        assert points.affine.device.type == "meta"
+
+    def test_bounding_boxes_to_moves_affine(self) -> None:
+        boxes = BoundingBoxes(
+            torch.rand(2, 6),
+            format=BoundingBoxFormat.IJKIJK,
+        )
+
+        boxes.to("meta")
+
+        assert boxes.device.type == "meta"
+        assert boxes.affine.device.type == "meta"
+
+
 class TestImageTo:
     def test_to_returns_self(self) -> None:
         image = tio.ScalarImage(torch.rand(1, 4, 4, 4))

--- a/tests/test_transforms_base.py
+++ b/tests/test_transforms_base.py
@@ -32,6 +32,14 @@ def _make_subject() -> tio.Subject:
     )
 
 
+def _make_image_subject() -> tio.Subject:
+    return tio.Subject(
+        t1=tio.ScalarImage(torch.rand(1, 8, 8, 8)),
+        seg=tio.LabelMap(torch.randint(0, 3, (1, 8, 8, 8))),
+        age=42,
+    )
+
+
 class _IdentityTransform(tio.Transform):
     """Transform that does nothing (for testing the base flow)."""
 
@@ -232,7 +240,7 @@ class TestIntensityTransform:
 
 class TestSpatialTransform:
     def test_all_images_modified(self) -> None:
-        subject = _make_subject()
+        subject = _make_image_subject()
         result = _FlipSpatial()(subject)
         # Both t1 and seg should be flipped
         assert result.t1.data.shape == (1, 8, 8, 8)
@@ -366,7 +374,7 @@ class TestAddOperator:
             tio.Flip(axes=(0,)) + 42  # type: ignore[operator]
 
     def test_add_produces_working_pipeline(self) -> None:
-        subject = _make_subject()
+        subject = _make_image_subject()
         pipeline = tio.Flip(axes=(0,)) + tio.Noise(std=0.01)
         result = pipeline(subject)
         assert result.t1.shape == subject.t1.shape
@@ -393,7 +401,7 @@ class TestOrOperator:
             tio.Flip(axes=(0,)) | "bad"  # type: ignore[operator]
 
     def test_or_produces_working_pipeline(self) -> None:
-        subject = _make_subject()
+        subject = _make_image_subject()
         pipeline = tio.Flip(axes=(0,)) | tio.Noise(std=0.01)
         result = pipeline(subject)
         assert result.t1.shape == subject.t1.shape


### PR DESCRIPTION
[Generated by a coding agent]

---

## Summary

- validate complete Subject and Image schemas before stacking
- preserve metadata, annotations, image subclasses, and shared/per-element histories
- support metadata-only and annotation-only batches
- add `SubjectsBatch.map_subjects()` for safe subject-wise processing
- reject spatial transforms on annotations until coordinate updates are supported

## Validation

- full test suite and cross-platform GitHub Actions
- Ruff lint and formatting
- ty type checking
- documentation tests and Zensical build
- pre-commit.ci, including Xenon complexity checks

## Stack (merge bottom-up)

1. ✅ [#1493 — documentation corrections](https://github.com/TorchIO-project/torchio/pull/1493) — merged
2. **#1494 — lossless subject batching (this PR; next to merge)**
3. [#1495 — exact transform parameter replay](https://github.com/TorchIO-project/torchio/pull/1495)
4. [#1496 — subject mapping adapters and examples](https://github.com/TorchIO-project/torchio/pull/1496)
