### PR TITLE
Add exact transform parameter replay

### DIFF
--- a/src/torchio/transforms/compose.py
+++ b/src/torchio/transforms/compose.py
@@ -65,6 +65,8 @@ class Compose(Transform):
         ... })
     """
 
+    _supports_apply_with_params = False
+
     def __init__(
         self,
         transforms: Sequence[Transform] | Mapping[str, Transform] | None = None,
@@ -121,6 +123,8 @@ class OneOf(Transform):
         ...     tio.Flip(axes=(0,)): 0.3,
         ... })
     """
+
+    _supports_apply_with_params = False
 
     def __init__(
         self,
@@ -207,6 +211,8 @@ class SomeOf(Transform):
         ...     num_transforms=2,
         ... )
     """
+
+    _supports_apply_with_params = False
 
     def __init__(
         self,
@@ -317,10 +323,9 @@ def _rebatch_with_history(subjects: list[Any], transform_name: str) -> Any:
     """
     from ..data.batch import SubjectsBatch
 
-    _check_consistent_schema(subjects, transform_name)
     try:
         batch = SubjectsBatch.from_subjects(subjects)
-    except (RuntimeError, KeyError) as error:
+    except ValueError as error:
         msg = (
             f"Per-instance {transform_name} produced batch elements with"
             " different shapes or schemas, which cannot be re-stacked. Use"
@@ -328,35 +333,5 @@ def _rebatch_with_history(subjects: list[Any], transform_name: str) -> Any:
             f" {transform_name}, or pass per_instance=False."
         )
         raise RuntimeError(msg) from error
-    batch.set_per_element_history([s.applied_transforms for s in subjects])
+    batch.set_per_element_history([subject.applied_transforms for subject in subjects])
     return batch
-
-
-def _check_consistent_schema(subjects: list[Any], transform_name: str) -> None:
-    """Ensure all subjects share the same image names and classes.
-
-    Per-element branching may apply different transforms to different
-    elements; if those change the set of images (or their type), the
-    elements can no longer be re-stacked into one batch. This raises a
-    clear error instead of silently dropping data.
-
-    Args:
-        subjects: The subjects about to be re-stacked.
-        transform_name: Name of the branching transform for the message.
-
-    Raises:
-        RuntimeError: If image names or classes differ across subjects.
-    """
-    if not subjects:
-        return
-    reference = {name: type(image) for name, image in subjects[0].images.items()}
-    for subject in subjects[1:]:
-        current = {name: type(image) for name, image in subject.images.items()}
-        if current != reference:
-            msg = (
-                f"Per-instance {transform_name} produced batch elements with"
-                " different image names or types, which cannot be re-stacked."
-                " Use only schema-preserving transforms with per-instance"
-                f" {transform_name}, or pass per_instance=False."
-            )
-            raise RuntimeError(msg)

--- a/src/torchio/transforms/cornucopia_adapter.py
+++ b/src/torchio/transforms/cornucopia_adapter.py
@@ -49,6 +49,8 @@ class CornucopiaAdapter(Transform):
         objects are not guaranteed to be serializable.
     """
 
+    _supports_apply_with_params = False
+
     def __init__(
         self,
         cornucopia_transform: Callable,

--- a/src/torchio/transforms/monai_adapter.py
+++ b/src/torchio/transforms/monai_adapter.py
@@ -57,6 +57,8 @@ class MonaiAdapter(Transform):
         serializable.
     """
 
+    _supports_apply_with_params = False
+
     def __init__(self, monai_transform: Callable, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         if not callable(monai_transform):

--- a/src/torchio/transforms/spatial/crop_or_pad.py
+++ b/src/torchio/transforms/spatial/crop_or_pad.py
@@ -431,6 +431,8 @@ class CropOrPad(SpatialTransform):
         >>> transform = tio.CropOrPad(target_shape=256, padding_mode='mean')
     """
 
+    _supports_apply_with_params = False
+
     def __init__(
         self,
         target_shape: TargetShapeParam,

--- a/src/torchio/transforms/spatial/ensure_shape_multiple.py
+++ b/src/torchio/transforms/spatial/ensure_shape_multiple.py
@@ -90,6 +90,8 @@ class EnsureShapeMultiple(SpatialTransform):
         >>> transform = tio.EnsureShapeMultiple((4, 8, 16))
     """
 
+    _supports_apply_with_params = False
+
     def __init__(
         self,
         target_multiple: TargetMultipleParam,

--- a/src/torchio/transforms/transform.py
+++ b/src/torchio/transforms/transform.py
@@ -153,11 +153,11 @@ def _validate_batched_value(
     if key not in params:
         msg = f"Batched parameter {key!r} is missing"
         raise ValueError(msg)
-    try:
-        actual_size = len(params[key])
-    except TypeError as error:
-        msg = f"Batched parameter {key!r} must contain {expected_size} values"
-        raise ValueError(msg) from error
+    value = params[key]
+    if not isinstance(value, list):
+        msg = f"Batched parameter {key!r} must be a list"
+        raise ValueError(msg)
+    actual_size = len(value)
     if actual_size != expected_size:
         msg = (
             f"Batched parameter {key!r} must contain"

--- a/src/torchio/transforms/transform.py
+++ b/src/torchio/transforms/transform.py
@@ -148,6 +148,8 @@ class Transform(nn.Module):
             which the transform will *not* be applied.
     """
 
+    _supports_apply_with_params = True
+
     def __init__(
         self,
         *,
@@ -255,26 +257,138 @@ class Transform(nn.Module):
         Args:
             data: Input data to transform.
         """
+        return self._execute(data, params=None, sample_params=True)
+
+    @overload
+    def apply_with_params(
+        self,
+        data: Subject,
+        params: dict[str, Any],
+    ) -> Subject: ...
+    @overload
+    def apply_with_params(
+        self,
+        data: Image,
+        params: dict[str, Any],
+    ) -> Image: ...
+    @overload
+    def apply_with_params(
+        self,
+        data: Tensor,
+        params: dict[str, Any],
+    ) -> Tensor: ...
+    @overload
+    def apply_with_params(
+        self,
+        data: np.ndarray,
+        params: dict[str, Any],
+    ) -> np.ndarray: ...
+    @overload
+    def apply_with_params(
+        self,
+        data: sitk.Image,
+        params: dict[str, Any],
+    ) -> sitk.Image: ...
+    @overload
+    def apply_with_params(
+        self,
+        data: nib.Nifti1Image,
+        params: dict[str, Any],
+    ) -> nib.Nifti1Image: ...
+    @overload
+    def apply_with_params(
+        self,
+        data: dict,
+        params: dict[str, Any],
+    ) -> dict: ...
+    @overload
+    def apply_with_params(
+        self,
+        data: ImagesBatch,
+        params: dict[str, Any],
+    ) -> ImagesBatch: ...
+    @overload
+    def apply_with_params(
+        self,
+        data: SubjectsBatch,
+        params: dict[str, Any],
+    ) -> SubjectsBatch: ...
+
+    def apply_with_params(
+        self,
+        data: Any,
+        params: dict[str, Any],
+    ) -> Any:
+        """Apply an exact parameter set without sampling.
+
+        This method bypasses the transform probability and
+        [`make_params()`][torchio.Transform.make_params], but otherwise
+        follows the normal transform lifecycle: copy handling, input
+        wrapping, output-type restoration, and history recording.
+
+        Args:
+            data: Input data to transform.
+            params: Exact parameters accepted by `apply_transform`.
+
+        Returns:
+            Transformed data with the same type as the input.
+
+        Raises:
+            NotImplementedError: If the transform does not expose one
+                exact-parameter kernel.
+            ValueError: If per-instance parameter dimensions do not
+                match the input batch.
+        """
+        if not self._supports_apply_with_params:
+            msg = (
+                f"{type(self).__name__}.apply_with_params() is not supported"
+                " because this transform does not expose a single"
+                " make_params/apply_transform parameter kernel."
+            )
+            raise NotImplementedError(msg)
+        if not isinstance(params, dict):
+            msg = f"Expected params to be a dict, got {type(params).__name__}"
+            raise TypeError(msg)
+        return self._execute(
+            data,
+            params=_copy.deepcopy(params),
+            sample_params=False,
+        )
+
+    def _execute(
+        self,
+        data: Any,
+        *,
+        params: dict[str, Any] | None,
+        sample_params: bool,
+    ) -> Any:
+        """Run the shared transform lifecycle."""
         self._check_spatial_annotations(data)
         if self.copy:
             data = _copy.deepcopy(data)
         batch, unwrap = self._wrap(data)
-        # When per-element gating is active, the transform handles the
-        # probability itself (masked-out elements get identity params),
-        # so skip the batch-wide coin flip here. Apply iff rand < p, so
-        # p=0 is always a no-op and p=1 always applies.
-        if not self._per_instance_p_active(batch) and torch.rand(1).item() >= self.p:
-            return unwrap(batch)
-        params = self.make_params(batch)
-        batch = self.apply_transform(batch, params)
+        if sample_params:
+            # When per-element gating is active, the transform handles
+            # probability itself (masked-out elements get identity params).
+            if (
+                not self._per_instance_p_active(batch)
+                and torch.rand(1).item() >= self.p
+            ):
+                return unwrap(batch)
+            resolved_params = self.make_params(batch)
+        else:
+            assert params is not None
+            self._validate_batched_params(params, batch)
+            resolved_params = params
+        batch = self.apply_transform(batch, resolved_params)
         # Record history on the batch, unless every element was gated out by
         # per-element probability: that is an exact no-op, and recording it
         # would let history replay (e.g. an invertible spatial transform)
         # trigger an unnecessary identity resample.
-        if not _all_elements_gated_out(params):
+        if not _all_elements_gated_out(resolved_params):
             trace = AppliedTransform(
                 name=type(self).__name__,
-                params=params,
+                params=resolved_params,
                 include=_copy_optional_list(self.include),
                 exclude=_copy_optional_list(self.exclude),
             )
@@ -294,6 +408,71 @@ class Transform(nn.Module):
             with contextlib.suppress(AttributeError):
                 result.applied_transforms = list(batch.applied_transforms)
         return result
+
+    @staticmethod
+    def _validate_batched_params(
+        params: dict[str, Any],
+        batch: SubjectsBatch,
+    ) -> None:
+        """Validate per-instance bookkeeping on an exact parameter set."""
+        has_batch_size = "_batch_size" in params
+        has_batched_keys = "_batched_keys" in params
+        has_keep = "_keep" in params
+        if not (has_batch_size or has_batched_keys or has_keep):
+            return
+        if not has_batch_size or not has_batched_keys:
+            msg = "Batched params must define both _batch_size and _batched_keys."
+            raise ValueError(msg)
+
+        expected_size = params["_batch_size"]
+        if (
+            isinstance(expected_size, bool)
+            or not isinstance(expected_size, int)
+            or expected_size < 1
+        ):
+            msg = f"_batch_size must be a positive integer, got {expected_size!r}"
+            raise ValueError(msg)
+        if expected_size != batch.batch_size:
+            msg = (
+                f"Parameter batch size {expected_size} does not match"
+                f" input batch size {batch.batch_size}"
+            )
+            raise ValueError(msg)
+
+        batched_keys = params["_batched_keys"]
+        if not isinstance(batched_keys, list) or not all(
+            isinstance(key, str) for key in batched_keys
+        ):
+            msg = "_batched_keys must be a list of parameter names"
+            raise ValueError(msg)
+        if len(set(batched_keys)) != len(batched_keys):
+            msg = "_batched_keys contains duplicate parameter names"
+            raise ValueError(msg)
+        for key in batched_keys:
+            if key not in params:
+                msg = f"Batched parameter {key!r} is missing"
+                raise ValueError(msg)
+            value = params[key]
+            try:
+                actual_size = len(value)
+            except TypeError as error:
+                msg = f"Batched parameter {key!r} must contain {expected_size} values"
+                raise ValueError(msg) from error
+            if actual_size != expected_size:
+                msg = (
+                    f"Batched parameter {key!r} must contain"
+                    f" {expected_size} values, got {actual_size}"
+                )
+                raise ValueError(msg)
+
+        if has_keep:
+            keep = params["_keep"]
+            if not isinstance(keep, list) or len(keep) != expected_size:
+                msg = f"_keep must contain {expected_size} boolean values, got {keep!r}"
+                raise ValueError(msg)
+            if not all(type(value) is bool for value in keep):
+                msg = "_keep values must be booleans"
+                raise ValueError(msg)
 
     def _check_spatial_annotations(self, data: Any) -> None:
         """Reject spatial transforms that would leave stale annotations."""

--- a/src/torchio/transforms/transform.py
+++ b/src/torchio/transforms/transform.py
@@ -334,6 +334,7 @@ class Transform(nn.Module):
             Transformed data with the same type as the input.
 
         Raises:
+            TypeError: If `params` is not a dictionary.
             NotImplementedError: If the transform does not expose one
                 exact-parameter kernel.
             ValueError: If per-instance parameter dimensions do not

--- a/src/torchio/transforms/transform.py
+++ b/src/torchio/transforms/transform.py
@@ -104,6 +104,80 @@ def _data_has_annotations(data: Any) -> bool:
             return False
 
 
+def _has_batched_param_metadata(params: dict[str, Any]) -> bool:
+    return any(key in params for key in ("_batch_size", "_batched_keys", "_keep"))
+
+
+def _get_expected_batch_size(
+    params: dict[str, Any],
+    batch: SubjectsBatch,
+) -> int:
+    if "_batch_size" not in params or "_batched_keys" not in params:
+        msg = "Batched params must define both _batch_size and _batched_keys."
+        raise ValueError(msg)
+    expected_size = params["_batch_size"]
+    if (
+        isinstance(expected_size, bool)
+        or not isinstance(expected_size, int)
+        or expected_size < 1
+    ):
+        msg = f"_batch_size must be a positive integer, got {expected_size!r}"
+        raise ValueError(msg)
+    if expected_size != batch.batch_size:
+        msg = (
+            f"Parameter batch size {expected_size} does not match"
+            f" input batch size {batch.batch_size}"
+        )
+        raise ValueError(msg)
+    return expected_size
+
+
+def _get_batched_keys(params: dict[str, Any]) -> list[str]:
+    batched_keys = params["_batched_keys"]
+    if not isinstance(batched_keys, list) or not all(
+        isinstance(key, str) for key in batched_keys
+    ):
+        msg = "_batched_keys must be a list of parameter names"
+        raise ValueError(msg)
+    if len(set(batched_keys)) != len(batched_keys):
+        msg = "_batched_keys contains duplicate parameter names"
+        raise ValueError(msg)
+    return batched_keys
+
+
+def _validate_batched_value(
+    params: dict[str, Any],
+    key: str,
+    expected_size: int,
+) -> None:
+    if key not in params:
+        msg = f"Batched parameter {key!r} is missing"
+        raise ValueError(msg)
+    try:
+        actual_size = len(params[key])
+    except TypeError as error:
+        msg = f"Batched parameter {key!r} must contain {expected_size} values"
+        raise ValueError(msg) from error
+    if actual_size != expected_size:
+        msg = (
+            f"Batched parameter {key!r} must contain"
+            f" {expected_size} values, got {actual_size}"
+        )
+        raise ValueError(msg)
+
+
+def _validate_keep(params: dict[str, Any], expected_size: int) -> None:
+    if "_keep" not in params:
+        return
+    keep = params["_keep"]
+    if not isinstance(keep, list) or len(keep) != expected_size:
+        msg = f"_keep must contain {expected_size} boolean values, got {keep!r}"
+        raise ValueError(msg)
+    if not all(type(value) is bool for value in keep):
+        msg = "_keep values must be booleans"
+        raise ValueError(msg)
+
+
 class Transform(nn.Module):
     """Abstract class for all TorchIO transforms.
 
@@ -368,47 +442,65 @@ class Transform(nn.Module):
         if self.copy:
             data = _copy.deepcopy(data)
         batch, unwrap = self._wrap(data)
-        if sample_params:
-            # When per-element gating is active, the transform handles
-            # probability itself (masked-out elements get identity params).
-            if (
-                not self._per_instance_p_active(batch)
-                and torch.rand(1).item() >= self.p
-            ):
-                return unwrap(batch)
-            resolved_params = self.make_params(batch)
-        else:
-            assert params is not None
-            self._validate_batched_params(params, batch)
-            resolved_params = params
+        if sample_params and self._should_skip(batch):
+            return unwrap(batch)
+        resolved_params = self._resolve_execution_params(
+            batch,
+            params,
+            sample_params,
+        )
         batch = self.apply_transform(batch, resolved_params)
-        # Record history on the batch, unless every element was gated out by
-        # per-element probability: that is an exact no-op, and recording it
-        # would let history replay (e.g. an invertible spatial transform)
-        # trigger an unnecessary identity resample.
-        if not _all_elements_gated_out(resolved_params):
-            trace = AppliedTransform(
-                name=type(self).__name__,
-                params=resolved_params,
-                include=_copy_optional_list(self.include),
-                exclude=_copy_optional_list(self.exclude),
-            )
-            if not hasattr(batch, "applied_transforms"):
-                batch.applied_transforms = []
-            batch.applied_transforms.append(trace)
+        self._record_applied_transform(batch, resolved_params)
         result = unwrap(batch)
-        # Propagate history to outputs that can carry it
-        if (
-            hasattr(batch, "applied_transforms")
-            and not isinstance(
-                result,
-                (ImagesBatch, SubjectsBatch, Tensor, np.ndarray),
-            )
-            and not isinstance(result, dict)
-        ):
-            with contextlib.suppress(AttributeError):
-                result.applied_transforms = list(batch.applied_transforms)
+        self._propagate_history(batch, result)
         return result
+
+    def _should_skip(self, batch: SubjectsBatch) -> bool:
+        """Return whether batch-wide probability skips this application."""
+        return not self._per_instance_p_active(batch) and torch.rand(1).item() >= self.p
+
+    def _resolve_execution_params(
+        self,
+        batch: SubjectsBatch,
+        params: dict[str, Any] | None,
+        sample_params: bool,
+    ) -> dict[str, Any]:
+        """Sample parameters or validate an exact supplied set."""
+        if sample_params:
+            return self.make_params(batch)
+        assert params is not None
+        self._validate_batched_params(params, batch)
+        return params
+
+    def _record_applied_transform(
+        self,
+        batch: SubjectsBatch,
+        params: dict[str, Any],
+    ) -> None:
+        """Append a history trace unless the application was an exact no-op."""
+        if _all_elements_gated_out(params):
+            return
+        trace = AppliedTransform(
+            name=type(self).__name__,
+            params=params,
+            include=_copy_optional_list(self.include),
+            exclude=_copy_optional_list(self.exclude),
+        )
+        if not hasattr(batch, "applied_transforms"):
+            batch.applied_transforms = []
+        batch.applied_transforms.append(trace)
+
+    @staticmethod
+    def _propagate_history(batch: SubjectsBatch, result: Any) -> None:
+        """Copy history to non-batch output types that can carry it."""
+        excluded_types = (ImagesBatch, SubjectsBatch, Tensor, np.ndarray, dict)
+        if not hasattr(batch, "applied_transforms") or isinstance(
+            result,
+            excluded_types,
+        ):
+            return
+        with contextlib.suppress(AttributeError):
+            result.applied_transforms = list(batch.applied_transforms)
 
     @staticmethod
     def _validate_batched_params(
@@ -416,64 +508,13 @@ class Transform(nn.Module):
         batch: SubjectsBatch,
     ) -> None:
         """Validate per-instance bookkeeping on an exact parameter set."""
-        has_batch_size = "_batch_size" in params
-        has_batched_keys = "_batched_keys" in params
-        has_keep = "_keep" in params
-        if not (has_batch_size or has_batched_keys or has_keep):
+        if not _has_batched_param_metadata(params):
             return
-        if not has_batch_size or not has_batched_keys:
-            msg = "Batched params must define both _batch_size and _batched_keys."
-            raise ValueError(msg)
-
-        expected_size = params["_batch_size"]
-        if (
-            isinstance(expected_size, bool)
-            or not isinstance(expected_size, int)
-            or expected_size < 1
-        ):
-            msg = f"_batch_size must be a positive integer, got {expected_size!r}"
-            raise ValueError(msg)
-        if expected_size != batch.batch_size:
-            msg = (
-                f"Parameter batch size {expected_size} does not match"
-                f" input batch size {batch.batch_size}"
-            )
-            raise ValueError(msg)
-
-        batched_keys = params["_batched_keys"]
-        if not isinstance(batched_keys, list) or not all(
-            isinstance(key, str) for key in batched_keys
-        ):
-            msg = "_batched_keys must be a list of parameter names"
-            raise ValueError(msg)
-        if len(set(batched_keys)) != len(batched_keys):
-            msg = "_batched_keys contains duplicate parameter names"
-            raise ValueError(msg)
+        expected_size = _get_expected_batch_size(params, batch)
+        batched_keys = _get_batched_keys(params)
         for key in batched_keys:
-            if key not in params:
-                msg = f"Batched parameter {key!r} is missing"
-                raise ValueError(msg)
-            value = params[key]
-            try:
-                actual_size = len(value)
-            except TypeError as error:
-                msg = f"Batched parameter {key!r} must contain {expected_size} values"
-                raise ValueError(msg) from error
-            if actual_size != expected_size:
-                msg = (
-                    f"Batched parameter {key!r} must contain"
-                    f" {expected_size} values, got {actual_size}"
-                )
-                raise ValueError(msg)
-
-        if has_keep:
-            keep = params["_keep"]
-            if not isinstance(keep, list) or len(keep) != expected_size:
-                msg = f"_keep must contain {expected_size} boolean values, got {keep!r}"
-                raise ValueError(msg)
-            if not all(type(value) is bool for value in keep):
-                msg = "_keep values must be booleans"
-                raise ValueError(msg)
+            _validate_batched_value(params, key, expected_size)
+        _validate_keep(params, expected_size)
 
     def _check_spatial_annotations(self, data: Any) -> None:
         """Reject spatial transforms that would leave stale annotations."""

--- a/tests/test_transforms_base.py
+++ b/tests/test_transforms_base.py
@@ -344,6 +344,14 @@ class TestApplyWithParams:
             ),
             (
                 {
+                    "value": (1, 2),
+                    "_batch_size": 2,
+                    "_batched_keys": ["value"],
+                },
+                "must be a list",
+            ),
+            (
+                {
                     "value": [1, 2],
                     "_batch_size": 2,
                     "_batched_keys": ["value"],

--- a/tests/test_transforms_base.py
+++ b/tests/test_transforms_base.py
@@ -65,6 +65,31 @@ class _FlipSpatial(tio.SpatialTransform):
         return batch
 
 
+class _AddFromParams(tio.Transform):
+    """Add an explicitly supplied value."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.make_params_calls = 0
+
+    def make_params(self, batch: Any) -> dict[str, Any]:
+        self.make_params_calls += 1
+        return {"value": 1.0}
+
+    def apply_transform(self, batch: Any, params: dict[str, Any]) -> Any:
+        for image_batch in batch.images.values():
+            image_batch.data = image_batch.data + params["value"]
+        return batch
+
+
+class _MutateParams(tio.Transform):
+    """Mutate params to test defensive copying."""
+
+    def apply_transform(self, batch: Any, params: dict[str, Any]) -> Any:
+        params["value"] = "mutated"
+        return batch
+
+
 # ── Transform base ───────────────────────────────────────────────────
 
 
@@ -193,6 +218,189 @@ class TestTransformBase:
     def test_invalid_input_type(self) -> None:
         with pytest.raises(TypeError):
             _IdentityTransform()("not a valid input")
+
+
+class TestApplyWithParams:
+    def test_bypasses_probability_and_sampling(self) -> None:
+        subject = tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4)))
+        transform = _AddFromParams(p=0)
+
+        result = transform.apply_with_params(subject, {"value": 2.0})
+
+        assert transform.make_params_calls == 0
+        torch.testing.assert_close(result.t1.data, torch.full_like(result.t1.data, 2))
+
+    def test_records_supplied_params(self) -> None:
+        subject = tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4)))
+
+        result = _AddFromParams().apply_with_params(subject, {"value": 2.0})
+
+        trace = result.applied_transforms[-1]
+        assert trace.name == "_AddFromParams"
+        assert trace.params == {"value": 2.0}
+
+    def test_preserves_prior_history(self) -> None:
+        subject = tio.Flip(axes=(0,))(
+            tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4)))
+        )
+
+        result = _AddFromParams().apply_with_params(subject, {"value": 2.0})
+
+        assert [trace.name for trace in result.applied_transforms] == [
+            "Flip",
+            "_AddFromParams",
+        ]
+
+    def test_does_not_mutate_caller_params(self) -> None:
+        subject = tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4)))
+        params = {"value": "original"}
+
+        _MutateParams().apply_with_params(subject, params)
+
+        assert params == {"value": "original"}
+
+    def test_copy_true_preserves_batch(self) -> None:
+        batch = tio.SubjectsBatch.from_subjects(
+            [tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4)))]
+        )
+
+        result = _AddFromParams(copy=True).apply_with_params(
+            batch,
+            {"value": 2.0},
+        )
+
+        assert result is not batch
+        assert torch.count_nonzero(batch.t1.data) == 0
+
+    def test_copy_false_mutates_batch(self) -> None:
+        batch = tio.SubjectsBatch.from_subjects(
+            [tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4)))]
+        )
+
+        result = _AddFromParams(copy=False).apply_with_params(
+            batch,
+            {"value": 2.0},
+        )
+
+        assert result is batch
+        assert torch.all(batch.t1.data == 2)
+
+    def test_replays_stochastic_transform_exactly(self) -> None:
+        subject = tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4)))
+        transform = tio.Noise(mean=(-1, 1), std=(0.1, 0.5))
+        transformed = transform(subject)
+        params = transformed.applied_transforms[-1].params
+
+        replayed = transform.apply_with_params(subject, params)
+
+        torch.testing.assert_close(replayed.t1.data, transformed.t1.data)
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4))),
+            tio.ScalarImage(torch.zeros(1, 4, 4, 4)),
+            torch.zeros(1, 4, 4, 4),
+            np.zeros((1, 4, 4, 4), dtype=np.float32),
+            sitk.Image(4, 4, 4, sitk.sitkFloat32),
+            nib.Nifti1Image(np.zeros((4, 4, 4)), np.eye(4)),
+            {"t1": torch.zeros(1, 4, 4, 4), "age": 42},
+            tio.ImagesBatch.from_images([tio.ScalarImage(torch.zeros(1, 4, 4, 4))]),
+            tio.SubjectsBatch.from_subjects(
+                [tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4)))]
+            ),
+        ],
+    )
+    def test_preserves_input_type(self, data: Any) -> None:
+        result = _IdentityTransform().apply_with_params(data, {})
+
+        assert type(result) is type(data)
+
+    @pytest.mark.parametrize(
+        ("params", "message"),
+        [
+            (
+                {
+                    "value": [1, 2],
+                    "_batch_size": 3,
+                    "_batched_keys": ["value"],
+                },
+                "batch size",
+            ),
+            (
+                {
+                    "_batch_size": 2,
+                    "_batched_keys": ["missing"],
+                },
+                "missing",
+            ),
+            (
+                {
+                    "value": [1],
+                    "_batch_size": 2,
+                    "_batched_keys": ["value"],
+                },
+                "2 values",
+            ),
+            (
+                {
+                    "value": [1, 2],
+                    "_batch_size": 2,
+                    "_batched_keys": ["value"],
+                    "_keep": [True],
+                },
+                "_keep",
+            ),
+            (
+                {
+                    "value": [1, 2],
+                    "_batch_size": 2,
+                    "_batched_keys": ["value"],
+                    "_keep": [True, 1],
+                },
+                "booleans",
+            ),
+        ],
+    )
+    def test_validates_batched_params(
+        self,
+        params: dict[str, Any],
+        message: str,
+    ) -> None:
+        batch = tio.SubjectsBatch.from_subjects(
+            [tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4))) for _ in range(2)]
+        )
+
+        with pytest.raises(ValueError, match=message):
+            _IdentityTransform().apply_with_params(batch, params)
+
+    def test_rejects_reserved_fields_without_batched_keys(self) -> None:
+        subject = tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4)))
+
+        with pytest.raises(ValueError, match="_batched_keys"):
+            _IdentityTransform().apply_with_params(
+                subject,
+                {"_batch_size": 1},
+            )
+
+    @pytest.mark.parametrize(
+        "transform",
+        [
+            tio.Compose([]),
+            tio.OneOf([_IdentityTransform()]),
+            tio.SomeOf([_IdentityTransform()]),
+            tio.MonaiAdapter(lambda value: value),
+            tio.CornucopiaAdapter(lambda value: value),
+        ],
+    )
+    def test_rejects_transforms_without_param_kernel(
+        self,
+        transform: tio.Transform,
+    ) -> None:
+        subject = tio.Subject(t1=tio.ScalarImage(torch.zeros(1, 4, 4, 4)))
+
+        with pytest.raises(NotImplementedError, match="apply_with_params"):
+            transform.apply_with_params(subject, {})
 
 
 # ── include/exclude ──────────────────────────────────────────────────

--- a/tests/test_transforms_base.py
+++ b/tests/test_transforms_base.py
@@ -391,6 +391,8 @@ class TestApplyWithParams:
             tio.SomeOf([_IdentityTransform()]),
             tio.MonaiAdapter(lambda value: value),
             tio.CornucopiaAdapter(lambda value: value),
+            tio.CropOrPad(4),
+            tio.EnsureShapeMultiple(2),
         ],
     )
     def test_rejects_transforms_without_param_kernel(


### PR DESCRIPTION
[Generated by a coding agent]

---

## Summary

- add `Transform.apply_with_params()` for exact parameter application
- share copy, wrapping, type restoration, annotation safety, and history handling with normal execution
- validate per-instance `_batch_size`, `_batched_keys`, and `_keep` dimensions
- bypass probability and sampling while preserving normal history semantics
- explicitly reject replay for composition, adapters, and lazy-only spatial transforms

## Validation

- full test suite and cross-platform GitHub Actions
- Ruff lint and formatting
- ty type checking
- documentation tests and Zensical build
- pre-commit.ci, including Xenon complexity checks

## Stack (merge bottom-up)

1. ✅ [#1493 — documentation corrections](https://github.com/TorchIO-project/torchio/pull/1493) — merged
2. [#1494 — lossless subject batching](https://github.com/TorchIO-project/torchio/pull/1494) — next to merge
3. **#1495 — exact transform parameter replay (this PR)**
4. [#1496 — subject mapping adapters and examples](https://github.com/TorchIO-project/torchio/pull/1496)
