### PR TITLE
docs: document distribution parameters and fix stale scalar rotation example

### DIFF
--- a/docs/reference/random_parameters.md
+++ b/docs/reference/random_parameters.md
@@ -14,3 +14,27 @@ the specification directly and the transform samples from it at apply time:
 ## Choice
 
 ::: torchio.Choice
+
+## Distribution
+
+For continuous randomness, pass any `torch.distributions.Distribution`.
+The transform draws a fresh sample from it each time it is applied, so
+you can use any distribution supported by PyTorch:
+
+<!-- pytest-codeblocks:skip -->
+```python
+import torch
+import torchio as tio
+
+# Sample the rotation angle from a normal distribution (mean 0°, std 5°)
+transform = tio.Affine(degrees=torch.distributions.Normal(0, 5))
+```
+
+A distribution can also be combined per axis with fixed values and
+ranges:
+
+<!-- pytest-codeblocks:skip -->
+```python
+# Fixed along I, uniform range along J, normal distribution along K
+transform = tio.Affine(degrees=(0, (-10, 10), torch.distributions.Normal(0, 5)))
+```

--- a/docs/tutorials/augmentation.md
+++ b/docs/tutorials/augmentation.md
@@ -41,7 +41,7 @@ a tuple gives a uniform range:
 tio.Affine(degrees=90)
 
 # Rotate uniformly between -15° and 15°
-tio.Affine(degrees=15)
+tio.Affine(degrees=(-15, 15))
 
 # Rotate uniformly between 5° and 20°
 tio.Affine(degrees=(5, 20))
@@ -61,6 +61,18 @@ You can mix `Choice`, ranges, and fixed values per axis:
 ```python
 # Fixed along I, random along J, discrete along K
 tio.Affine(degrees=(0, (-10, 10), tio.Choice([-90, 0, 90])))
+```
+
+For continuous sampling beyond a uniform range, pass any
+`torch.distributions.Distribution`.  A fresh value is drawn each time
+the transform is applied:
+
+<!-- pytest-codeblocks:skip -->
+```python
+import torch
+
+# Sample the rotation angle from a normal distribution (mean 0°, std 5°)
+tio.Affine(degrees=torch.distributions.Normal(0, 5))
 ```
 
 ## Probability control


### PR DESCRIPTION
**Description**

small docs-only change to the random-parameter docs:

- the augmentation tutorial showed `tio.Affine(degrees=15)` with the comment "rotate uniformly between -15° and 15°", but in v2 a scalar is deterministic (it always rotates 15°). changed the example to `degrees=(-15, 15)` so it matches the comment.
- `Distribution` is listed as a valid parameter spec in the reference and mentioned in the tutorial and migration guide, but it was never shown anywhere. added a `## Distribution` section to `reference/random_parameters.md` (parallel to `## Choice`) plus a short example in the tutorial, covering both broadcasting and per-axis mixing.

checked that every snippet runs against the current code.

**Checklist**

- [x] I have read the [`CONTRIBUTING`](https://github.com/TorchIO-project/torchio/blob/main/CONTRIBUTING.md) docs and have a developer setup ready
- Changes are
  - [x] Non-breaking (would not break existing functionality)
  - [ ] Breaking (would cause existing functionality to change)
- [ ] Tests added or modified to cover the changes
- [ ] In-line docstrings updated
- [x] Documentation updated
- [x] This pull request is ready to be reviewed
