### PR TITLE
Restore statistical padding modes

### DIFF
--- a/src/torchio/data/sampler.py
+++ b/src/torchio/data/sampler.py
@@ -17,7 +17,7 @@ from .patch import PatchLocation
 from .subject import Subject
 
 if TYPE_CHECKING:
-    from ..transforms.spatial.pad import PaddingMode
+    from ..transforms.spatial._padding import PaddingMode
 
 
 class PatchSampler:

--- a/src/torchio/data/sampler.py
+++ b/src/torchio/data/sampler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import TYPE_CHECKING
 from typing import Any
 
 import numpy as np
@@ -14,6 +15,9 @@ from torch.utils.data import IterableDataset
 from ..types import TypeThreeInts
 from .patch import PatchLocation
 from .subject import Subject
+
+if TYPE_CHECKING:
+    from ..transforms.spatial.pad import PaddingMode
 
 
 class PatchSampler:
@@ -95,7 +99,7 @@ class GridSampler(PatchSampler, Dataset):
         subject: Subject,
         patch_size: int | TypeThreeInts,
         patch_overlap: int | TypeThreeInts = 0,
-        padding_mode: str | None = None,
+        padding_mode: PaddingMode | None = None,
         fill: float = 0,
     ) -> None:
         super().__init__(patch_size)

--- a/src/torchio/transforms/_statistics.py
+++ b/src/torchio/transforms/_statistics.py
@@ -1,0 +1,43 @@
+"""Shared statistical helpers for transforms."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def compute_quantile(values: Tensor, q: float) -> Tensor:
+    """Compute a single quantile of a one-dimensional tensor.
+
+    `torch.quantile` raises `RuntimeError: quantile() input tensor is too
+    large` for inputs with more than `2**24` elements, which is easily
+    reached by high-resolution volumes. `torch.kthvalue` has no such size
+    limit and is much faster on large tensors, so it is used here with linear
+    interpolation to reproduce the default `torch.quantile` behavior.
+
+    This is adapted from the solution by Elie Goudout (`@ego-thales`):
+    https://github.com/pytorch/pytorch/issues/157431#issuecomment-3026856373
+
+    Args:
+        values: One-dimensional tensor of values.
+        q: Quantile to compute, in the `[0, 1]` range.
+
+    Returns:
+        Zero-dimensional tensor with the computed quantile.
+
+    Raises:
+        ValueError: If `q` is outside the `[0, 1]` range.
+    """
+    if not 0 <= q <= 1:
+        msg = f"Only values 0 <= q <= 1 are supported, but got {q!r}"
+        raise ValueError(msg)
+    index = q * (values.numel() - 1)
+    lower = math.floor(index)
+    lower_value = torch.kthvalue(values, lower + 1).values
+    if index == lower:
+        return lower_value
+    upper_value = torch.kthvalue(values, lower + 2).values
+    weight = index - lower
+    return lower_value.lerp(upper_value, weight)

--- a/src/torchio/transforms/intensity/normalize.py
+++ b/src/torchio/transforms/intensity/normalize.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 import warnings
 from collections.abc import Callable
 from typing import Any
@@ -14,6 +13,7 @@ from torch import Tensor
 from ...data.batch import ImagesBatch
 from ...data.batch import SubjectsBatch
 from ...data.image import LabelMap
+from .._statistics import compute_quantile
 from ..parameter_range import Choice
 from ..parameter_range import _ParameterRange
 from ..transform import IntensityTransform
@@ -360,44 +360,9 @@ def _percentile_range(
         )
         values = tensor.reshape(-1)
 
-    low = float(_quantile(values.float(), pct_low / 100.0).item())
-    high = float(_quantile(values.float(), pct_high / 100.0).item())
+    low = float(compute_quantile(values.float(), pct_low / 100.0).item())
+    high = float(compute_quantile(values.float(), pct_high / 100.0).item())
     return low, high
-
-
-def _quantile(values: Tensor, q: float) -> Tensor:
-    """Compute a single quantile of a 1D tensor using ``torch.kthvalue``.
-
-    ``torch.quantile`` raises ``RuntimeError: quantile() input tensor is too
-    large`` for inputs with more than ``2**24`` elements, which is easily
-    reached by high-resolution volumes. ``torch.kthvalue`` has no such size
-    limit and is much faster on large tensors, so it is used here with linear
-    interpolation to reproduce the default ``torch.quantile`` behaviour.
-
-    This is adapted from the solution by Élie Goudout (``@ego-thales``):
-    https://github.com/pytorch/pytorch/issues/157431#issuecomment-3026856373
-
-    Args:
-        values: One-dimensional tensor of values.
-        q: Quantile to compute, in the ``[0, 1]`` range.
-
-    Returns:
-        Zero-dimensional tensor with the computed quantile.
-
-    Raises:
-        ValueError: If ``q`` is outside the ``[0, 1]`` range.
-    """
-    if not 0 <= q <= 1:
-        msg = f"Only values 0 <= q <= 1 are supported, but got {q!r}"
-        raise ValueError(msg)
-    index = q * (values.numel() - 1)
-    lower = math.floor(index)
-    lower_value = torch.kthvalue(values, lower + 1).values
-    if index == lower:
-        return lower_value
-    upper_value = torch.kthvalue(values, lower + 2).values
-    weight = index - lower
-    return lower_value.lerp(upper_value, weight)
 
 
 # Backwards-compatible alias.

--- a/src/torchio/transforms/spatial/_padding.py
+++ b/src/torchio/transforms/spatial/_padding.py
@@ -1,0 +1,97 @@
+"""Shared spatial padding helpers."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Literal
+from typing import get_args
+
+import torch
+from torch import Tensor
+
+from ...types import TypeSixInts
+from ..intensity.normalize import _quantile
+
+#: Accepted padding modes.
+PaddingMode = Literal[
+    "constant",
+    "reflect",
+    "replicate",
+    "circular",
+    "mean",
+    "median",
+    "minimum",
+]
+
+_PADDING_MODES: tuple[PaddingMode, ...] = get_args(PaddingMode)
+_STATISTIC_PADDING_MODES = "mean", "median", "minimum"
+
+
+def parse_padding_mode(padding_mode: str) -> PaddingMode:
+    """Validate and return a padding mode."""
+    if padding_mode not in _PADDING_MODES:
+        msg = f"padding_mode must be one of {_PADDING_MODES}, got {padding_mode!r}"
+        raise ValueError(msg)
+    return padding_mode
+
+
+def _compute_padding_statistic(
+    data: Tensor,
+    padding_mode: PaddingMode,
+) -> Tensor:
+    """Compute one whole-volume padding statistic per batch element."""
+    flat = data.flatten(start_dim=1)
+    if padding_mode == "minimum":
+        return flat.amin(dim=1)
+
+    if not torch.is_floating_point(data):
+        warnings.warn(
+            f'The constant value computed for padding mode "{padding_mode}"'
+            " might be truncated in the output, as the data type of the input"
+            " image is not float. Consider converting the image to a floating"
+            " point type before applying this transform.",
+            RuntimeWarning,
+            stacklevel=4,
+        )
+
+    float_flat = flat if data.dtype in (torch.float32, torch.float64) else flat.float()
+    if padding_mode == "mean":
+        statistic = float_flat.mean(dim=1)
+    else:
+        statistic = torch.stack(
+            [_quantile(values, 0.5) for values in float_flat],
+        )
+    return statistic.to(data.dtype)
+
+
+def pad_tensor(
+    data: Tensor,
+    padding: TypeSixInts,
+    padding_mode: PaddingMode,
+    fill: float,
+) -> Tensor:
+    """Pad a 4D image tensor or 5D image batch."""
+    assert data.ndim in (4, 5)
+    i0, i1, j0, j1, k0, k1 = padding
+    pad_arg = k0, k1, j0, j1, i0, i1
+    if padding_mode not in _STATISTIC_PADDING_MODES:
+        return torch.nn.functional.pad(
+            data,
+            pad_arg,
+            mode=padding_mode,
+            value=fill,
+        )
+
+    is_unbatched = data.ndim == 4
+    batch = data.unsqueeze(0) if is_unbatched else data
+    statistic = _compute_padding_statistic(batch, padding_mode)
+    padded = torch.nn.functional.pad(batch, pad_arg)
+    interior = torch.ones(
+        (1, 1, *batch.shape[-3:]),
+        dtype=torch.bool,
+        device=batch.device,
+    )
+    interior = torch.nn.functional.pad(interior, pad_arg)
+    fill_values = statistic.reshape(-1, 1, 1, 1, 1)
+    result = torch.where(interior, padded, fill_values)
+    return result[0] if is_unbatched else result

--- a/src/torchio/transforms/spatial/_padding.py
+++ b/src/torchio/transforms/spatial/_padding.py
@@ -10,7 +10,7 @@ import torch
 from torch import Tensor
 
 from ...types import TypeSixInts
-from ..intensity.normalize import _quantile
+from .._statistics import compute_quantile
 
 #: Accepted padding modes.
 PaddingMode = Literal[
@@ -59,7 +59,7 @@ def _compute_padding_statistic(
         statistic = float_flat.mean(dim=1)
     else:
         statistic = torch.stack(
-            [_quantile(values, 0.5) for values in float_flat],
+            [compute_quantile(values, 0.5) for values in float_flat],
         )
     return statistic.to(data.dtype)
 

--- a/src/torchio/transforms/spatial/_padding.py
+++ b/src/torchio/transforms/spatial/_padding.py
@@ -71,7 +71,9 @@ def pad_tensor(
     fill: float,
 ) -> Tensor:
     """Pad a 4D image tensor or 5D image batch."""
-    assert data.ndim in (4, 5)
+    if data.ndim not in (4, 5):
+        msg = f"Expected a 4D or 5D image tensor, got {data.ndim}D"
+        raise ValueError(msg)
     i0, i1, j0, j1, k0, k1 = padding
     pad_arg = k0, k1, j0, j1, i0, i1
     if padding_mode not in _STATISTIC_PADDING_MODES:

--- a/src/torchio/transforms/spatial/crop_or_pad.py
+++ b/src/torchio/transforms/spatial/crop_or_pad.py
@@ -29,6 +29,9 @@ from ..transform import AppliedTransform
 from ..transform import SpatialTransform
 from .crop import Crop
 from .pad import Pad
+from .pad import PaddingMode
+from .pad import _pad_tensor
+from .pad import _parse_padding_mode
 
 #: Accepted target shape specifications.
 #: `int` or `float` → same size for each axis.
@@ -208,7 +211,7 @@ class _PaddedBackend:
         padding: TypeSixInts,
         padded_shape: tuple[int, int, int, int],
         affine: TypeAffineMatrix,
-        padding_mode: str = "constant",
+        padding_mode: PaddingMode = "constant",
         fill: float = 0,
     ) -> None:
         self._source = source
@@ -234,13 +237,11 @@ class _PaddedBackend:
 
     def to_tensor(self) -> Tensor:
         base = self._source.to_tensor()
-        i0, i1, j0, j1, k0, k1 = self._padding
-        pad_arg = (k0, k1, j0, j1, i0, i1)
-        return torch.nn.functional.pad(
+        return _pad_tensor(
             base,
-            pad_arg,
-            mode=self._padding_mode,
-            value=self._fill,
+            self._padding,
+            self._padding_mode,
+            self._fill,
         )
 
     def __getitem__(self, slices: SliceIndex) -> Tensor:
@@ -318,7 +319,7 @@ def _crop_image_lazy(image: Image, cropping: TypeSixInts) -> Image:
 def _pad_image_lazy(
     image: Image,
     padding: TypeSixInts,
-    padding_mode: str,
+    padding_mode: PaddingMode,
     fill: float,
 ) -> Image:
     """Pad an image lazily (data is only loaded when accessed)."""
@@ -336,12 +337,11 @@ def _pad_image_lazy(
     padded_shape = (c, si + i0 + i1, sj + j0 + j1, sk + k0 + k1)
 
     if image.is_loaded:
-        pad_arg = (k0, k1, j0, j1, i0, i1)
-        new_data = torch.nn.functional.pad(
+        new_data = _pad_tensor(
             image.data,
-            pad_arg,
-            mode=padding_mode,
-            value=fill,
+            padding,
+            padding_mode,
+            fill,
         )
         return image.new_like(data=new_data, affine=new_affine)
 
@@ -369,12 +369,11 @@ def _pad_image_lazy(
         return new
 
     # No backend → fall back to eager pad
-    pad_arg = (k0, k1, j0, j1, i0, i1)
-    new_data = torch.nn.functional.pad(
+    new_data = _pad_tensor(
         image.data,
-        pad_arg,
-        mode=padding_mode,
-        value=fill,
+        padding,
+        padding_mode,
+        fill,
     )
     return image.new_like(data=new_data, affine=new_affine)
 
@@ -403,8 +402,11 @@ class CropOrPad(SpatialTransform):
         units: Coordinate system for `target_shape`. One of
             `"voxels"` (default), `"mm"`, or `"cm"`.
         padding_mode: One of `'constant'`, `'reflect'`,
-            `'replicate'`, or `'circular'`. See
-            [`torch.nn.functional.pad`](https://pytorch.org/docs/stable/generated/torch.nn.functional.pad.html).
+            `'replicate'`, `'circular'`, `'mean'`, `'median'`, or
+            `'minimum'`. Statistical modes use one value computed from
+            the whole image volume. For integer inputs, `'mean'` and
+            `'median'` may be truncated to the input dtype and emit a
+            warning.
         fill: Fill value when `padding_mode='constant'`.
         only_crop: If `True`, padding is never applied. Mutually
             exclusive with `only_pad`.
@@ -426,6 +428,7 @@ class CropOrPad(SpatialTransform):
         >>> transform = tio.CropOrPad(target_shape=256, only_pad=True)
         >>> transform = tio.CropOrPad(target_shape=(256, 256, None))  # keep depth
         >>> transform = tio.CropOrPad(target_shape=96, location='random')
+        >>> transform = tio.CropOrPad(target_shape=256, padding_mode='mean')
     """
 
     def __init__(
@@ -452,7 +455,7 @@ class CropOrPad(SpatialTransform):
             raise ValueError(msg)
         self.target_shape = _parse_target_shape(target_shape)
         self.units: Units = units
-        self.padding_mode = padding_mode
+        self.padding_mode = _parse_padding_mode(padding_mode)
         self.fill = fill
         self.only_crop = only_crop
         self.only_pad = only_pad

--- a/src/torchio/transforms/spatial/crop_or_pad.py
+++ b/src/torchio/transforms/spatial/crop_or_pad.py
@@ -436,7 +436,7 @@ class CropOrPad(SpatialTransform):
         target_shape: TargetShapeParam,
         *,
         units: Units = "voxels",
-        padding_mode: str = "constant",
+        padding_mode: PaddingMode = "constant",
         fill: float = 0,
         only_crop: bool = False,
         only_pad: bool = False,

--- a/src/torchio/transforms/spatial/crop_or_pad.py
+++ b/src/torchio/transforms/spatial/crop_or_pad.py
@@ -27,11 +27,11 @@ from ...types import TypeThreeInts
 from ..compose import Compose
 from ..transform import AppliedTransform
 from ..transform import SpatialTransform
+from ._padding import PaddingMode
+from ._padding import pad_tensor
+from ._padding import parse_padding_mode
 from .crop import Crop
 from .pad import Pad
-from .pad import PaddingMode
-from .pad import _pad_tensor
-from .pad import _parse_padding_mode
 
 #: Accepted target shape specifications.
 #: `int` or `float` → same size for each axis.
@@ -237,7 +237,7 @@ class _PaddedBackend:
 
     def to_tensor(self) -> Tensor:
         base = self._source.to_tensor()
-        return _pad_tensor(
+        return pad_tensor(
             base,
             self._padding,
             self._padding_mode,
@@ -337,7 +337,7 @@ def _pad_image_lazy(
     padded_shape = (c, si + i0 + i1, sj + j0 + j1, sk + k0 + k1)
 
     if image.is_loaded:
-        new_data = _pad_tensor(
+        new_data = pad_tensor(
             image.data,
             padding,
             padding_mode,
@@ -369,7 +369,7 @@ def _pad_image_lazy(
         return new
 
     # No backend → fall back to eager pad
-    new_data = _pad_tensor(
+    new_data = pad_tensor(
         image.data,
         padding,
         padding_mode,
@@ -455,7 +455,7 @@ class CropOrPad(SpatialTransform):
             raise ValueError(msg)
         self.target_shape = _parse_target_shape(target_shape)
         self.units: Units = units
-        self.padding_mode = _parse_padding_mode(padding_mode)
+        self.padding_mode = parse_padding_mode(padding_mode)
         self.fill = fill
         self.only_crop = only_crop
         self.only_pad = only_pad

--- a/src/torchio/transforms/spatial/ensure_shape_multiple.py
+++ b/src/torchio/transforms/spatial/ensure_shape_multiple.py
@@ -11,6 +11,7 @@ from ...data.subject import Subject
 from ...types import TypeThreeInts
 from ..transform import SpatialTransform
 from .crop_or_pad import CropOrPad
+from .pad import PaddingMode
 
 #: Accepted target_multiple specifications.
 #: `int` → same value for all axes.
@@ -74,7 +75,8 @@ class EnsureShapeMultiple(SpatialTransform):
             multiple.
         padding_mode: Padding mode forwarded to `CropOrPad` when
             `method='pad'`. One of `'constant'`, `'reflect'`,
-            `'replicate'`, or `'circular'`.
+            `'replicate'`, `'circular'`, `'mean'`, `'median'`, or
+            `'minimum'`.
         fill: Fill value when `padding_mode='constant'`.
         **kwargs: See [`Transform`][torchio.Transform] for additional
             keyword arguments.
@@ -92,7 +94,7 @@ class EnsureShapeMultiple(SpatialTransform):
         target_multiple: TargetMultipleParam,
         *,
         method: str = "pad",
-        padding_mode: str = "constant",
+        padding_mode: PaddingMode = "constant",
         fill: float = 0,
         **kwargs: Any,
     ) -> None:

--- a/src/torchio/transforms/spatial/ensure_shape_multiple.py
+++ b/src/torchio/transforms/spatial/ensure_shape_multiple.py
@@ -10,8 +10,8 @@ from ...data.image import Image
 from ...data.subject import Subject
 from ...types import TypeThreeInts
 from ..transform import SpatialTransform
+from ._padding import PaddingMode
 from .crop_or_pad import CropOrPad
-from .pad import PaddingMode
 
 #: Accepted target_multiple specifications.
 #: `int` → same value for all axes.

--- a/src/torchio/transforms/spatial/ensure_shape_multiple.py
+++ b/src/torchio/transforms/spatial/ensure_shape_multiple.py
@@ -11,6 +11,7 @@ from ...data.subject import Subject
 from ...types import TypeThreeInts
 from ..transform import SpatialTransform
 from ._padding import PaddingMode
+from ._padding import parse_padding_mode
 from .crop_or_pad import CropOrPad
 
 #: Accepted target_multiple specifications.
@@ -104,7 +105,7 @@ class EnsureShapeMultiple(SpatialTransform):
             msg = f"method must be 'crop' or 'pad', got {method!r}"
             raise ValueError(msg)
         self.method = method
-        self.padding_mode = padding_mode
+        self.padding_mode = parse_padding_mode(padding_mode)
         self.fill = fill
 
     def forward(self, data: Any) -> Any:

--- a/src/torchio/transforms/spatial/pad.py
+++ b/src/torchio/transforms/spatial/pad.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
+from typing import Literal
 
 import torch
+from torch import Tensor
 
 from ...data.batch import SubjectsBatch
 from ...types import TypeSixInts
 from ...types import TypeThreeInts
+from ..intensity.normalize import _quantile
 from ..transform import SpatialTransform
 
 #: Accepted padding specifications.
@@ -16,6 +20,29 @@ from ..transform import SpatialTransform
 #: 3-tuple → symmetric per axis `(i, j, k)`.
 #: 6-tuple → per-side `(i_ini, i_fin, j_ini, j_fin, k_ini, k_fin)`.
 PaddingParam = int | TypeThreeInts | TypeSixInts
+
+#: Accepted padding modes.
+PaddingMode = Literal[
+    "constant",
+    "reflect",
+    "replicate",
+    "circular",
+    "mean",
+    "median",
+    "minimum",
+]
+
+_PADDING_MODES: tuple[PaddingMode, ...] = (
+    "constant",
+    "reflect",
+    "replicate",
+    "circular",
+    "mean",
+    "median",
+    "minimum",
+)
+
+_STATISTIC_PADDING_MODES = ("mean", "median", "minimum")
 
 
 def _parse_padding(padding: PaddingParam) -> TypeSixInts:
@@ -31,6 +58,76 @@ def _parse_padding(padding: PaddingParam) -> TypeSixInts:
         return (values[0], values[1], values[2], values[3], values[4], values[5])
     msg = f"Padding must have 1, 3, or 6 values, got {n}"
     raise ValueError(msg)
+
+
+def _parse_padding_mode(padding_mode: str) -> PaddingMode:
+    """Validate and return a padding mode."""
+    if padding_mode not in _PADDING_MODES:
+        msg = f"padding_mode must be one of {_PADDING_MODES}, got {padding_mode!r}"
+        raise ValueError(msg)
+    return padding_mode
+
+
+def _compute_padding_statistic(
+    data: Tensor,
+    padding_mode: PaddingMode,
+) -> Tensor:
+    """Compute one whole-volume padding statistic per batch element."""
+    flat = data.flatten(start_dim=1)
+    if padding_mode == "minimum":
+        return flat.amin(dim=1)
+
+    if not torch.is_floating_point(data):
+        warnings.warn(
+            f'The constant value computed for padding mode "{padding_mode}"'
+            " might be truncated in the output, as the data type of the input"
+            " image is not float. Consider converting the image to a floating"
+            " point type before applying this transform.",
+            RuntimeWarning,
+            stacklevel=4,
+        )
+
+    float_flat = flat.float()
+    if padding_mode == "mean":
+        statistic = float_flat.mean(dim=1)
+    else:
+        statistic = torch.stack(
+            [_quantile(values, 0.5) for values in float_flat],
+        )
+    return statistic.to(data.dtype)
+
+
+def _pad_tensor(
+    data: Tensor,
+    padding: TypeSixInts,
+    padding_mode: PaddingMode,
+    fill: float,
+) -> Tensor:
+    """Pad a 4D image tensor or 5D image batch."""
+    assert data.ndim in (4, 5)
+    i0, i1, j0, j1, k0, k1 = padding
+    pad_arg = k0, k1, j0, j1, i0, i1
+    if padding_mode not in _STATISTIC_PADDING_MODES:
+        return torch.nn.functional.pad(
+            data,
+            pad_arg,
+            mode=padding_mode,
+            value=fill,
+        )
+
+    is_unbatched = data.ndim == 4
+    batch = data.unsqueeze(0) if is_unbatched else data
+    statistic = _compute_padding_statistic(batch, padding_mode)
+    padded = torch.nn.functional.pad(batch, pad_arg)
+    interior = torch.ones(
+        (1, 1, *batch.shape[-3:]),
+        dtype=torch.bool,
+        device=batch.device,
+    )
+    interior = torch.nn.functional.pad(interior, pad_arg)
+    fill_values = statistic.reshape(-1, 1, 1, 1, 1)
+    result = torch.where(interior, padded, fill_values)
+    return result[0] if is_unbatched else result
 
 
 class Pad(SpatialTransform):
@@ -50,8 +147,11 @@ class Pad(SpatialTransform):
             $i_\text{ini} = i_\text{fin} = i$, etc.
             If only one value $n$ is provided, all six values are $n$.
         padding_mode: One of `'constant'`, `'reflect'`,
-            `'replicate'`, or `'circular'`. See
-            [`torch.nn.functional.pad`](https://pytorch.org/docs/stable/generated/torch.nn.functional.pad.html).
+            `'replicate'`, `'circular'`, `'mean'`, `'median'`, or
+            `'minimum'`. Statistical modes use one value computed from
+            the whole image volume. For integer inputs, `'mean'` and
+            `'median'` may be truncated to the input dtype and emit a
+            warning.
         fill: Fill value when `padding_mode='constant'`.
         **kwargs: See [`Transform`][torchio.Transform] for additional
             keyword arguments.
@@ -61,6 +161,7 @@ class Pad(SpatialTransform):
         >>> transform = tio.Pad(padding=10)
         >>> transform = tio.Pad(padding=(5, 10, 0))
         >>> transform = tio.Pad(padding=10, padding_mode='reflect')
+        >>> transform = tio.Pad(padding=10, padding_mode='minimum')
     """
 
     def __init__(
@@ -73,7 +174,7 @@ class Pad(SpatialTransform):
     ) -> None:
         super().__init__(**kwargs)
         self.padding = _parse_padding(padding)
-        self.padding_mode = padding_mode
+        self.padding_mode = _parse_padding_mode(padding_mode)
         self.fill = fill
 
     def make_params(self, batch: SubjectsBatch) -> dict[str, Any]:
@@ -91,14 +192,12 @@ class Pad(SpatialTransform):
         i0, i1, j0, j1, k0, k1 = params["padding"]
         mode = params["padding_mode"]
         fill = params["fill"]
-        # F.pad expects reversed order: (k0, k1, j0, j1, i0, i1)
-        pad_arg = (k0, k1, j0, j1, i0, i1)
         for _name, img_batch in self._get_images(batch).items():
-            img_batch.data = torch.nn.functional.pad(
+            img_batch.data = _pad_tensor(
                 img_batch.data,
-                pad_arg,
-                mode=mode,
-                value=fill,
+                (i0, i1, j0, j1, k0, k1),
+                mode,
+                fill,
             )
             # Update each affine's origin (shift back)
             for affine in img_batch.affines:

--- a/src/torchio/transforms/spatial/pad.py
+++ b/src/torchio/transforms/spatial/pad.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from typing import Any
 from typing import Literal
+from typing import get_args
 
 import torch
 from torch import Tensor
@@ -32,15 +33,7 @@ PaddingMode = Literal[
     "minimum",
 ]
 
-_PADDING_MODES: tuple[PaddingMode, ...] = (
-    "constant",
-    "reflect",
-    "replicate",
-    "circular",
-    "mean",
-    "median",
-    "minimum",
-)
+_PADDING_MODES: tuple[PaddingMode, ...] = get_args(PaddingMode)
 
 _STATISTIC_PADDING_MODES = ("mean", "median", "minimum")
 

--- a/src/torchio/transforms/spatial/pad.py
+++ b/src/torchio/transforms/spatial/pad.py
@@ -80,7 +80,7 @@ def _compute_padding_statistic(
             stacklevel=4,
         )
 
-    float_flat = flat.float()
+    float_flat = flat if data.dtype in (torch.float32, torch.float64) else flat.float()
     if padding_mode == "mean":
         statistic = float_flat.mean(dim=1)
     else:

--- a/src/torchio/transforms/spatial/pad.py
+++ b/src/torchio/transforms/spatial/pad.py
@@ -35,7 +35,7 @@ PaddingMode = Literal[
 
 _PADDING_MODES: tuple[PaddingMode, ...] = get_args(PaddingMode)
 
-_STATISTIC_PADDING_MODES = ("mean", "median", "minimum")
+_STATISTIC_PADDING_MODES = "mean", "median", "minimum"
 
 
 def _parse_padding(padding: PaddingParam) -> TypeSixInts:

--- a/src/torchio/transforms/spatial/pad.py
+++ b/src/torchio/transforms/spatial/pad.py
@@ -161,7 +161,7 @@ class Pad(SpatialTransform):
         self,
         *,
         padding: PaddingParam,
-        padding_mode: str = "constant",
+        padding_mode: PaddingMode = "constant",
         fill: float = 0,
         **kwargs: Any,
     ) -> None:

--- a/src/torchio/transforms/spatial/pad.py
+++ b/src/torchio/transforms/spatial/pad.py
@@ -2,40 +2,21 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import Any
-from typing import Literal
-from typing import get_args
-
-import torch
-from torch import Tensor
 
 from ...data.batch import SubjectsBatch
 from ...types import TypeSixInts
 from ...types import TypeThreeInts
-from ..intensity.normalize import _quantile
 from ..transform import SpatialTransform
+from ._padding import PaddingMode
+from ._padding import pad_tensor
+from ._padding import parse_padding_mode
 
 #: Accepted padding specifications.
 #: `int` → same amount on each side of each axis.
 #: 3-tuple → symmetric per axis `(i, j, k)`.
 #: 6-tuple → per-side `(i_ini, i_fin, j_ini, j_fin, k_ini, k_fin)`.
 PaddingParam = int | TypeThreeInts | TypeSixInts
-
-#: Accepted padding modes.
-PaddingMode = Literal[
-    "constant",
-    "reflect",
-    "replicate",
-    "circular",
-    "mean",
-    "median",
-    "minimum",
-]
-
-_PADDING_MODES: tuple[PaddingMode, ...] = get_args(PaddingMode)
-
-_STATISTIC_PADDING_MODES = "mean", "median", "minimum"
 
 
 def _parse_padding(padding: PaddingParam) -> TypeSixInts:
@@ -51,76 +32,6 @@ def _parse_padding(padding: PaddingParam) -> TypeSixInts:
         return (values[0], values[1], values[2], values[3], values[4], values[5])
     msg = f"Padding must have 1, 3, or 6 values, got {n}"
     raise ValueError(msg)
-
-
-def _parse_padding_mode(padding_mode: str) -> PaddingMode:
-    """Validate and return a padding mode."""
-    if padding_mode not in _PADDING_MODES:
-        msg = f"padding_mode must be one of {_PADDING_MODES}, got {padding_mode!r}"
-        raise ValueError(msg)
-    return padding_mode
-
-
-def _compute_padding_statistic(
-    data: Tensor,
-    padding_mode: PaddingMode,
-) -> Tensor:
-    """Compute one whole-volume padding statistic per batch element."""
-    flat = data.flatten(start_dim=1)
-    if padding_mode == "minimum":
-        return flat.amin(dim=1)
-
-    if not torch.is_floating_point(data):
-        warnings.warn(
-            f'The constant value computed for padding mode "{padding_mode}"'
-            " might be truncated in the output, as the data type of the input"
-            " image is not float. Consider converting the image to a floating"
-            " point type before applying this transform.",
-            RuntimeWarning,
-            stacklevel=4,
-        )
-
-    float_flat = flat if data.dtype in (torch.float32, torch.float64) else flat.float()
-    if padding_mode == "mean":
-        statistic = float_flat.mean(dim=1)
-    else:
-        statistic = torch.stack(
-            [_quantile(values, 0.5) for values in float_flat],
-        )
-    return statistic.to(data.dtype)
-
-
-def _pad_tensor(
-    data: Tensor,
-    padding: TypeSixInts,
-    padding_mode: PaddingMode,
-    fill: float,
-) -> Tensor:
-    """Pad a 4D image tensor or 5D image batch."""
-    assert data.ndim in (4, 5)
-    i0, i1, j0, j1, k0, k1 = padding
-    pad_arg = k0, k1, j0, j1, i0, i1
-    if padding_mode not in _STATISTIC_PADDING_MODES:
-        return torch.nn.functional.pad(
-            data,
-            pad_arg,
-            mode=padding_mode,
-            value=fill,
-        )
-
-    is_unbatched = data.ndim == 4
-    batch = data.unsqueeze(0) if is_unbatched else data
-    statistic = _compute_padding_statistic(batch, padding_mode)
-    padded = torch.nn.functional.pad(batch, pad_arg)
-    interior = torch.ones(
-        (1, 1, *batch.shape[-3:]),
-        dtype=torch.bool,
-        device=batch.device,
-    )
-    interior = torch.nn.functional.pad(interior, pad_arg)
-    fill_values = statistic.reshape(-1, 1, 1, 1, 1)
-    result = torch.where(interior, padded, fill_values)
-    return result[0] if is_unbatched else result
 
 
 class Pad(SpatialTransform):
@@ -167,7 +78,7 @@ class Pad(SpatialTransform):
     ) -> None:
         super().__init__(**kwargs)
         self.padding = _parse_padding(padding)
-        self.padding_mode = _parse_padding_mode(padding_mode)
+        self.padding_mode = parse_padding_mode(padding_mode)
         self.fill = fill
 
     def make_params(self, batch: SubjectsBatch) -> dict[str, Any]:
@@ -186,7 +97,7 @@ class Pad(SpatialTransform):
         mode = params["padding_mode"]
         fill = params["fill"]
         for _name, img_batch in self._get_images(batch).items():
-            img_batch.data = _pad_tensor(
+            img_batch.data = pad_tensor(
                 img_batch.data,
                 (i0, i1, j0, j1, k0, k1),
                 mode,

--- a/tests/test_crop_or_pad.py
+++ b/tests/test_crop_or_pad.py
@@ -235,6 +235,26 @@ class TestPaddingMode:
         )(subject)
         assert result.t1.shape == (1, 8, 8, 8)
 
+    @pytest.mark.parametrize(
+        ("padding_mode", "expected"),
+        [
+            ("mean", 3.5),
+            ("median", 3.5),
+            ("minimum", 0),
+        ],
+    )
+    def test_statistic_mode_tensor_path(
+        self,
+        padding_mode: str,
+        expected: float,
+    ) -> None:
+        tensor = torch.arange(8, dtype=torch.float32).reshape(1, 2, 2, 2)
+        result = tio.CropOrPad(
+            target_shape=4,
+            padding_mode=padding_mode,
+        )(tensor)
+        assert result[0, 0, 0, 0].item() == expected
+
 
 # ---------------------------------------------------------------------------
 # AffineMatrix correctness
@@ -531,6 +551,30 @@ class TestLazyBackends:
         subject = tio.Subject(t1=image)
         result = tio.CropOrPad(target_shape=12)(subject)
         assert result.t1.affine is not None
+
+    @pytest.mark.parametrize(
+        ("padding_mode", "expected"),
+        [
+            ("mean", 3.5),
+            ("median", 3.5),
+            ("minimum", 0),
+        ],
+    )
+    def test_pad_lazy_backend_statistic_mode(
+        self,
+        tmp_path,
+        padding_mode: str,
+        expected: float,
+    ) -> None:
+        path = tmp_path / "test.nii.gz"
+        data = np.arange(8, dtype=np.float32).reshape(2, 2, 2)
+        nib.save(nib.Nifti1Image(data, np.eye(4)), path)
+        result = tio.CropOrPad(
+            target_shape=4,
+            padding_mode=padding_mode,
+        )(tio.Subject(t1=tio.ScalarImage(path)))
+        assert not result.t1.is_loaded
+        assert result.t1.data[0, 0, 0, 0].item() == expected
 
     def test_crop_and_pad_lazy_mixed(self, tmp_path) -> None:
         """Anisotropic shape needing both crop and pad."""

--- a/tests/test_ensure_shape_multiple.py
+++ b/tests/test_ensure_shape_multiple.py
@@ -106,6 +106,10 @@ class TestValidation:
         with pytest.raises(ValueError, match="method"):
             tio.EnsureShapeMultiple(8, method="resize")
 
+    def test_invalid_padding_mode_raises(self) -> None:
+        with pytest.raises(ValueError, match="padding_mode"):
+            tio.EnsureShapeMultiple(8, padding_mode="maximum")  # type: ignore[arg-type]
+
     def test_method_must_be_crop_or_pad(self) -> None:
         # Valid methods should not raise
         tio.EnsureShapeMultiple(8, method="crop")

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 import torchio as tio
+from torchio.transforms._statistics import compute_quantile
 
 
 def _make_subject(
@@ -230,30 +231,24 @@ class TestAlias:
 
 
 class TestQuantile:
-    """Tests for the ``torch.kthvalue``-based ``_quantile`` helper."""
+    """Tests for the `torch.kthvalue`-based quantile helper."""
 
     @pytest.mark.parametrize("q", [0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0])
     def test_matches_torch_quantile(self, q: float) -> None:
-        from torchio.transforms.intensity.normalize import _quantile
-
         values = torch.linspace(-3.0, 7.0, 101)
         expected = torch.quantile(values, q)
-        result = _quantile(values, q)
+        result = compute_quantile(values, q)
         assert torch.allclose(result, expected, atol=1e-5)
 
     def test_invalid_q_raises(self) -> None:
-        from torchio.transforms.intensity.normalize import _quantile
-
         values = torch.arange(10, dtype=torch.float32)
         with pytest.raises(ValueError, match="0 <= q <= 1"):
-            _quantile(values, 1.5)
+            compute_quantile(values, 1.5)
 
     def test_large_tensor_interior_quantile(self) -> None:
-        from torchio.transforms.intensity.normalize import _quantile
-
         # torch.quantile raises for more than 2**24 elements; kthvalue does not.
         values = torch.arange(2**24 + 1, dtype=torch.float32)
-        result = _quantile(values, 0.5)
+        result = compute_quantile(values, 0.5)
         assert result.item() == pytest.approx(2**23)
 
     def test_rescale_intensity_large_image(self) -> None:

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -8,9 +8,19 @@ import pytest
 import torch
 
 import torchio as tio
+from torchio.transforms.spatial._padding import pad_tensor
 
 
 class TestPad:
+    def test_pad_tensor_rejects_invalid_number_of_dimensions(self) -> None:
+        with pytest.raises(ValueError, match="4D or 5D"):
+            pad_tensor(
+                torch.ones(2, 2, 2),
+                (0, 0, 0, 0, 0, 0),
+                "mean",
+                0,
+            )
+
     def test_pad_uniform(self) -> None:
         image = tio.ScalarImage(torch.rand(1, 10, 10, 10))
         subject = tio.Subject(t1=image)

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -134,6 +134,25 @@ class TestPad:
         result.sum().backward()
         assert tensor.grad is not None
 
+    @pytest.mark.parametrize("padding_mode", ["mean", "median"])
+    def test_pad_statistic_mode_preserves_float64_precision(
+        self,
+        padding_mode: str,
+    ) -> None:
+        values = torch.tensor([1.0, 1.0 + 2**-40], dtype=torch.float64)
+        tensor = values.reshape(1, 1, 1, 2)
+        result = tio.Pad(
+            padding=(0, 0, 0, 1, 0, 0),
+            padding_mode=padding_mode,
+        )(tensor)
+        expected = values.mean()
+        torch.testing.assert_close(
+            result[0, 0, 1, 0],
+            expected,
+            rtol=0,
+            atol=0,
+        )
+
     def test_pad_all_images(self) -> None:
         subject = tio.Subject(
             t1=tio.ScalarImage(torch.rand(1, 10, 10, 10)),

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import warnings
+
+import pytest
 import torch
 
 import torchio as tio
@@ -41,6 +44,95 @@ class TestPad:
         subject = tio.Subject(t1=image)
         result = tio.Pad(padding=1, padding_mode="reflect")(subject)
         assert result.t1.shape == (1, 6, 6, 6)
+
+    def test_invalid_padding_mode(self) -> None:
+        with pytest.raises(ValueError, match="padding_mode"):
+            tio.Pad(padding=1, padding_mode="maximum")
+
+    @pytest.mark.parametrize(
+        ("padding_mode", "expected"),
+        [
+            ("mean", 1.5),
+            ("median", 1.5),
+            ("minimum", 0),
+        ],
+    )
+    def test_pad_statistic_mode(
+        self,
+        padding_mode: str,
+        expected: float,
+    ) -> None:
+        tensor = torch.arange(4, dtype=torch.float32).reshape(1, 1, 2, 2)
+        result = tio.Pad(
+            padding=(0, 0, 0, 1, 0, 0),
+            padding_mode=padding_mode,
+        )(tensor)
+        torch.testing.assert_close(
+            result[0, 0, 2],
+            torch.full((2,), expected, dtype=tensor.dtype),
+        )
+
+    @pytest.mark.parametrize("padding_mode", ["mean", "median", "minimum"])
+    def test_pad_statistic_mode_per_batch_element(
+        self,
+        padding_mode: str,
+    ) -> None:
+        subjects = [
+            tio.Subject(t1=tio.ScalarImage(torch.full((1, 2, 2, 2), value)))
+            for value in (1.0, 3.0)
+        ]
+        batch = tio.SubjectsBatch.from_subjects(subjects)
+        result = tio.Pad(padding=1, padding_mode=padding_mode)(batch)
+        torch.testing.assert_close(
+            result.t1.data[:, 0, 0, 0, 0],
+            torch.tensor([1.0, 3.0]),
+        )
+
+    @pytest.mark.parametrize(
+        ("padding_mode", "expected"),
+        [
+            ("mean", 0),
+            ("median", 1),
+        ],
+    )
+    def test_pad_statistic_mode_warns_for_integer_truncation(
+        self,
+        padding_mode: str,
+        expected: int,
+    ) -> None:
+        tensor = torch.tensor([0, 1, 1, 1]).reshape(1, 1, 2, 2)
+        with pytest.warns(RuntimeWarning, match="might be truncated"):
+            result = tio.Pad(
+                padding=(0, 0, 0, 1, 0, 0),
+                padding_mode=padding_mode,
+            )(tensor)
+        assert result.dtype == tensor.dtype
+        assert result[0, 0, 2, 0].item() == expected
+
+    def test_pad_minimum_does_not_warn_for_integer_input(self) -> None:
+        tensor = torch.tensor([0, 1, 1, 1]).reshape(1, 1, 2, 2)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = tio.Pad(
+                padding=(0, 0, 0, 1, 0, 0),
+                padding_mode="minimum",
+            )(tensor)
+        assert result[0, 0, 2, 0].item() == 0
+        assert not any(issubclass(item.category, RuntimeWarning) for item in caught)
+
+    @pytest.mark.parametrize("padding_mode", ["mean", "median", "minimum"])
+    def test_pad_statistic_mode_is_differentiable(
+        self,
+        padding_mode: str,
+    ) -> None:
+        tensor = torch.rand(1, 2, 2, 2, requires_grad=True)
+        result = tio.Pad(
+            padding=1,
+            padding_mode=padding_mode,
+            copy=False,
+        )(tensor)
+        result.sum().backward()
+        assert tensor.grad is not None
 
     def test_pad_all_images(self) -> None:
         subject = tio.Subject(


### PR DESCRIPTION
[Generated by a coding agent]

---

## Summary

- restore `mean`, `median`, and `minimum` padding modes in `Pad` and `CropOrPad`
- preserve whole-volume, per-subject statistics across eager, batched, and lazy paths
- retain dtype, device, gradient, affine, and integer truncation behavior

## Testing

- `uv run --group test pytest tests/test_pad.py tests/test_crop_or_pad.py -q`
- `mise run quality`