### PR TITLE
Fix padding mode type narrowing

### DIFF
--- a/src/torchio/transforms/spatial/_padding.py
+++ b/src/torchio/transforms/spatial/_padding.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 from typing import Literal
+from typing import TypeGuard
 from typing import get_args
 
 import torch
@@ -27,9 +28,13 @@ _PADDING_MODES: tuple[PaddingMode, ...] = get_args(PaddingMode)
 _STATISTIC_PADDING_MODES = "mean", "median", "minimum"
 
 
+def _is_padding_mode(value: str) -> TypeGuard[PaddingMode]:
+    return value in _PADDING_MODES
+
+
 def parse_padding_mode(padding_mode: str) -> PaddingMode:
     """Validate and return a padding mode."""
-    if padding_mode not in _PADDING_MODES:
+    if not _is_padding_mode(padding_mode):
         msg = f"padding_mode must be one of {_PADDING_MODES}, got {padding_mode!r}"
         raise ValueError(msg)
     return padding_mode


### PR DESCRIPTION
[Generated by a coding agent]

---

## What

Fix `parse_padding_mode()` so `ty` narrows a validated string to the `PaddingMode` literal type.

## Why

Current `main` fails the repository's `ty` hook because membership in `_PADDING_MODES` does not narrow `str` to the literal union. The batching-redesign stack needs a clean `prek` baseline before changing unrelated batching code.

## How

- add a small `TypeGuard[PaddingMode]` helper
- validate through the type guard before returning the input string
- keep the same runtime validation and error message

## Validation

- targeted spatial padding tests
- ty
- full prek hook suite

This PR is an independent prerequisite for the batching-redesign stack.
